### PR TITLE
webpack - fix typo

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -9,7 +9,7 @@ let user = require('./user')
 
 // e.g. peer-id -> PeerId
 const libraryName = upperFirst(camelCase(user.pkg.name))
-const specific = merge(user.customPkg || {}, user.customPkg || {})
+const specific = user.customPkg || {}
 const entry = user.entry || 'src/index.js'
 
 const shared = {


### PR DESCRIPTION
I assume it was a mistake to merge the same obj together.
I assume there is no side effect to removing the merge and just returning the obj.