### PR TITLE
Add <rootDir> to ignore patterns for jest

### DIFF
--- a/src/config/jest.js
+++ b/src/config/jest.js
@@ -7,8 +7,8 @@ module.exports = {
     '**/test/**/*.js'
   ],
   testPathIgnorePatterns: [
-    '/node_modules/',
-    '/src/'
+    '<rootDir>/node_modules/',
+    '<rootDir>/src/'
   ],
   setupTestFrameworkScriptFile: path.join(__dirname, 'jest-setup.js'),
   rootDir: process.cwd(),

--- a/src/config/jest.js
+++ b/src/config/jest.js
@@ -7,7 +7,7 @@ module.exports = {
     '**/test/**/*.js'
   ],
   testPathIgnorePatterns: [
-    '<rootDir>/node_modules/',
+    '/node_modules/',
     '<rootDir>/src/'
   ],
   setupTestFrameworkScriptFile: path.join(__dirname, 'jest-setup.js'),


### PR DESCRIPTION
This fixes the issue where /src/ couldn't be a part of the full path and makes sure we only match from our workspace

Closes #150