### PR TITLE
fix: add exit option back to fix buggy tests

### DIFF
--- a/cmds/coverage.js
+++ b/cmds/coverage.js
@@ -42,6 +42,10 @@ module.exports = {
       describe: 'Do not include passed in files in the coverage report',
       type: 'array',
       default: []
+    },
+    exit: {
+      describe: 'force shutdown of the event loop after test run: mocha will call process.exit',
+      default: true
     }
   },
   handler (argv) {

--- a/cmds/release.js
+++ b/cmds/release.js
@@ -66,6 +66,10 @@ module.exports = {
       describe: 'Custom globs for files to test',
       type: 'array',
       default: []
+    },
+    exit: {
+      describe: 'force shutdown of the event loop after test run: mocha will call process.exit',
+      default: true
     }
   },
   handler (argv) {

--- a/cmds/test.js
+++ b/cmds/test.js
@@ -42,6 +42,10 @@ module.exports = {
       describe: 'The default time a single test has to run',
       type: 'number',
       default: 5000
+    },
+    exit: {
+      describe: 'force shutdown of the event loop after test run: mocha will call process.exit',
+      default: true
     }
   },
   handler (argv) {

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -41,6 +41,10 @@ function testNode (ctx) {
     args.push('--watch')
   }
 
+  if (ctx.exit) {
+    args.push('--exit')
+  }
+
   if (ctx.coverage) {
     exec = 'nyc'
     args = [


### PR DESCRIPTION
Mocha 3 defaulted to force exit processes after tests were done. In Mocha 4 this is not the case anymore. As some tests/implementations are currently not properly cleaning up after themselves this adds this option back by default. 


References:

- https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#default-behavior
- https://github.com/mochajs/mocha/issues/2879
- https://www.npmjs.com/package/why-is-node-running
- https://boneskull.com/mocha-v4-nears-release/