### PR TITLE
feat: add timeout flag for mocha runs and increase default to 5000

### DIFF
--- a/src/test/node.js
+++ b/src/test/node.js
@@ -5,7 +5,7 @@ const path = require('path')
 
 const utils = require('../utils')
 
-global.DEFAULT_TIMEOUT = global.DEFAULT_TIMEOUT || 5 * 1000
+const DEFAULT_TIMEOUT = global.DEFAULT_TIMEOUT || 5 * 1000
 
 const coverageFiles = [
   'src/**/*.js'
@@ -59,7 +59,7 @@ function testNode (ctx) {
     ].concat(args)
   }
 
-  ctx.timeout = ctx.timeout || global.DEFAULT_TIMEOUT
+  ctx.timeout = ctx.timeout || DEFAULT_TIMEOUT
   args = [
     '--timeout',
     ctx.timeout

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -5,6 +5,8 @@ const path = require('path')
 
 const utils = require('../utils')
 
+global.DEFAULT_TIMEOUT = global.DEFAULT_TIMEOUT || 5 * 1000
+
 const coverageFiles = [
   'src/**/*.js'
 ]
@@ -56,6 +58,12 @@ function testNode (ctx) {
       'mocha'
     ].concat(args)
   }
+
+  ctx.timeout = ctx.timeout || global.DEFAULT_TIMEOUT
+  args = [
+    '--timeout',
+    ctx.timeout
+  ].concat(args)
 
   const postHook = utils.hook('node', 'post')
   const preHook = utils.hook('node', 'pre')


### PR DESCRIPTION
adding `--timeout` flag for mocha runs as well as increasing timeout to 5000, same as jest.