### PR TITLE
Fix messed-up variables

### DIFF
--- a/src/build/browser.js
+++ b/src/build/browser.js
@@ -39,7 +39,8 @@ function minify (ctx, task) {
   return fs.readFile(path.join(process.cwd(), 'dist', 'index.js'))
     .then((code) => {
       const result = Uglify.minify(code.toString(), {
-        mangle: false
+        mangle: false,
+        compress: false
       })
       if (result.error) {
         throw result.error


### PR DESCRIPTION
For some reason, Uglify is messing up with some variables on js-ipfs. Here's a quick fix.

This closes https://github.com/ipfs/js-ipfs/issues/1131