### PR TITLE
Load files from package.json if exists

### DIFF
--- a/src/test/index.js
+++ b/src/test/index.js
@@ -2,32 +2,43 @@
 
 const pmap = require('p-map')
 const _ = require('lodash')
+const path = require('path')
 
 const node = require('./node')
 const browser = require('./browser')
 
 const userConfig = require('../config/user')
 
+const taskEnabled = (ctx, name) => _.includes(ctx.target, name)
+
 const TASKS = [{
+  id: 'node',
   title: 'Test Node.js',
-  task: node,
-  enabled: (ctx) => _.includes(ctx.target, 'node')
+  task: node
 }, {
+  id: 'browser',
   title: 'Test Browser',
-  task: browser.default,
-  enabled: (ctx) => _.includes(ctx.target, 'browser')
+  task: browser.default
 }, {
+  id: 'webworker',
   title: 'Test Webworker',
-  task: browser.webworker,
-  enabled: (ctx) => _.includes(ctx.target, 'webworker')
+  task: browser.webworker
 }]
 
 module.exports = {
   run (opts) {
+    const pkg = require(path.join(process.cwd(), 'package.json'))
     opts.hooks = userConfig().hooks
     return pmap(TASKS, (task) => {
-      if (!task.enabled(opts)) {
+      if (!taskEnabled(opts, task.id)) {
         return Promise.resolve()
+      }
+
+      if (pkg.aegir) {
+        const pkgOpts = pkg.aegir.test[task.id]
+        if (pkgOpts && pkgOpts.files) {
+          opts.files = pkgOpts.files
+        }
       }
 
       console.log(task.title)


### PR DESCRIPTION
This adds the option of adding which files to load for testing via a
addition in the package.json instead of just commandline arguments.

Example:

```
{
  "aegir": {
    "test": {
      "browser": {
        "files": ["test/browser.spec.js"]
      },
      "webworker": {
        "files": ["test/browser.spec.js"]
      }
    }
  }
}
```

With this configuration, aegir would run all tests with node, but only
`test/browser.spec.js` in browser and webworker tests.

Solves #181