### PR TITLE
docs: give advice on aegir release error

### DIFF
--- a/src/release/prerelease.js
+++ b/src/release/prerelease.js
@@ -10,7 +10,8 @@ function validGh (opts) {
   }
 
   if (!opts.ghtoken) {
-    return Promise.reject(new Error('Missing GitHub access token'))
+    return Promise.reject(new Error('Missing GitHub access token. ' +
+                                    'Have you set `AEGIR_GHTOKEN`?'))
   }
   return Promise.resolve()
 }


### PR DESCRIPTION
If you want to publish a package on npm you need to provide
a GitHub access token. This is normally done through the
`AEGIR_GHTOKEN` environment variable. Add this information to
the error message if such a token is missing.