### PR TITLE
Don't verify on push

### DIFF
--- a/src/release/commit.js
+++ b/src/release/commit.js
@@ -17,10 +17,7 @@ function commit () {
     version = res[1].version
     return pify(git.commit.bind(git))(
       `chore: release version v${version}`,
-      files,
-      {
-        '--no-verify': true
-      }
+      files
     )
   }).then(() => pify(git.addTag.bind(git))(`v${version}`))
 }

--- a/src/release/push.js
+++ b/src/release/push.js
@@ -9,6 +9,8 @@ function push () {
     remote,
     'master',
     {
+      // Linter and tests were already run by previous steps
+      '--no-verify': true,
       '--tags': true
     }
   )


### PR DESCRIPTION
Projects are moving from pre-commit hook to pre-push hooks.

Linting and testing is already done in separate steps before
the push, hence don't run the pre-push hook when pushing to
GitHub.

Fixes #192.