### PR TITLE
feat: allow to load fixtures from paths other than ./test

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ a method to do this. For it to work you have to put your fixtures in the folder 
 // test/awesome.spec.js
 const loadFixture = require('aegir/fixtures')
 
-const myFixture = loadFixture(__dirname, 'fixtures/largefixture')
+const myFixture = loadFixture('test/fixtures/largefixture')
 ```
+
+The path to the fixture is relative to the module root.
 
 If you write a module like [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core)
 which is to be consumed by other modules tests you need to pass in a third parameter such that
@@ -131,8 +133,9 @@ For example
 // awesome-tests module
 const loadFixture = require('aegir/fixtures')
 
-const myFixture = loadFixture(__dirname, 'fixtures/coolfixture', 'awesome-tests')
+const myFixture = loadFixture('test/fixtures/coolfixture', 'awesome-tests')
 ```
+
 
 ```js
 // tests for module using the awesome-tests

--- a/src/fixtures.js
+++ b/src/fixtures.js
@@ -4,25 +4,21 @@
 const isNode = require('detect-node')
 const path = require('path')
 
-module.exports = function loadFixtures (dirname, filePath, module) {
+module.exports = function loadFixtures (filePath, module) {
+  if (module) {
+    filePath = path.join('node_modules', module, filePath)
+  }
+
   if (isNode) {
-    return require('fs').readFileSync(path.join(dirname, filePath))
+    return require('fs').readFileSync(path.join(process.cwd(), filePath))
   } else {
-    return syncXhr(filePath, module)
+    return syncXhr(filePath)
   }
 }
 
 // @dignifiedquire: I know this is considered bad practice, but it makes testing life so much nicer!
-function syncXhr (filePath, module) {
-  let target
-  if (module) {
-    target = path.join('/base', 'node_modules', module, filePath)
-    console.log('module is', module)
-    console.log('filePath is', filePath)
-    console.log('target is', target)
-  } else {
-    target = path.join('/base', filePath)
-  }
+function syncXhr (filePath) {
+  const target = path.join('/base', filePath)
 
   const request = new self.XMLHttpRequest()
   request.open('GET', target, false)

--- a/src/fixtures.js
+++ b/src/fixtures.js
@@ -5,6 +5,7 @@ const isNode = require('detect-node')
 const path = require('path')
 
 module.exports = function loadFixtures (filePath, module) {
+  // note: filePath needs to be relative to the module root
   if (module) {
     filePath = path.join('node_modules', module, filePath)
   }

--- a/src/fixtures.js
+++ b/src/fixtures.js
@@ -1,25 +1,29 @@
+/* global self */
 'use strict'
 
 const isNode = require('detect-node')
 const path = require('path')
-const Buffer = require('safe-buffer').Buffer
 
-module.exports = function loadFixtures (dirname, file, module) {
+module.exports = function loadFixtures (dirname, filePath, module) {
   if (isNode) {
-    return require('fs').readFileSync(path.join(dirname, file))
+    return require('fs').readFileSync(path.join(dirname, filePath))
   } else {
-    return syncXhr(file, module)
+    return syncXhr(filePath, module)
   }
 }
 
-// I know this is considered bad practice, but it makes testing life so much nicer!
-function syncXhr (url, module) {
+// @dignifiedquire: I know this is considered bad practice, but it makes testing life so much nicer!
+function syncXhr (filePath, module) {
   let target
   if (module) {
-    target = path.join('/base', 'node_modules', module, 'test', url)
+    target = path.join('/base', 'node_modules', module, filePath)
+    console.log('module is', module)
+    console.log('filePath is', filePath)
+    console.log('target is', target)
   } else {
-    target = path.join('/base', 'test', url)
+    target = path.join('/base', filePath)
   }
+
   const request = new self.XMLHttpRequest()
   request.open('GET', target, false)
   request.overrideMimeType('text/plain; charset=x-user-defined')

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -6,7 +6,7 @@ const expect = require('chai').expect
 
 describe('browser', () => {
   it('fixtures', () => {
-    const myFixture = loadFixture(__dirname, 'test/fixtures/test.txt')
+    const myFixture = loadFixture('test/fixtures/test.txt')
     expect(myFixture.toString()).to.be.eql('Hello Fixture\n')
   })
 

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -6,7 +6,7 @@ const expect = require('chai').expect
 
 describe('browser', () => {
   it('fixtures', () => {
-    const myFixture = loadFixture(__dirname, 'fixtures/test.txt')
+    const myFixture = loadFixture(__dirname, 'test/fixtures/test.txt')
     expect(myFixture.toString()).to.be.eql('Hello Fixture\n')
   })
 


### PR DESCRIPTION
needed for: https://github.com/ipfs/js-ipfs-api/pull/689

**warning: this is a breaking change for how fixtures get loaded**