### PR TITLE
Explicitly load plugins for karma

### DIFF
--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -25,6 +25,16 @@ module.exports = function (config) {
     webpackMiddleware: {
       noInfo: true
     },
+    plugins: config.plugins.concat([
+      'karma-webpack',
+      'karma-sourcemap-loader',
+      'karma-mocha',
+      'karma-mocha-webworker',
+      'karma-mocha-own-reporter',
+      'karma-junit-reporter',
+      'karma-chrome-launcher',
+      'karma-firefox-launcher'
+    ].map(m => require(m))),
     reporters: reporters,
     mochaOwnReporter: {
       reporter: 'spec'


### PR DESCRIPTION
By default, karma loads plugins from sibling modules that starts with
`karma-*`. When a package manager (yarn in this case) has a version
conflict, node_modules turns into a tree with nested node_modules/
instead of 100% flat. This makes karma not be able to get the module.

This fix makes it explicitly which plugins we want to load, so it can
work in any of the node_modules modes (tree vs flat)