### PR TITLE
fix: don't run test/*.spec.js files automatically in Browsers

### DIFF
--- a/src/test/browser-config.js
+++ b/src/test/browser-config.js
@@ -14,8 +14,7 @@ function getPatterns (ctx) {
   }
 
   return [
-    'test/browser.js',
-    'test/**/*.spec.js'
+    'test/browser.js'
   ]
 }
 


### PR DESCRIPTION
For Browsers we use webpack. Karma will create a bundle for every file
that is specified as entry point. This may take lots of resources (see
https://github.com/ipfs/js-ipfs-api/issues/683 for more information).

The solution is to have only a single entry point, `test/browser.js`,
which will then be responsible to create the bundle with all the tests.

BREAKING CHANGE: Without bundling all tests in `test/browser.js` the
tests might not run. The bundling can be done like this:

    // This is webpack specific. It will create a single bundle
    // out of all files ending in ".spec.js" within the "test"
    // directory and all its subdirectories.
    'use strict'
    const testsContext = require.context('.', true, /\.spec\.js/)
    testsContext.keys().forEach(testsContext)