### PR TITLE
fix: make a single webpack bundle

### DIFF
--- a/src/config/karma-webpack-bundle.js
+++ b/src/config/karma-webpack-bundle.js
@@ -1,0 +1,15 @@
+/* global TEST_DIR */
+// This is webpack specific. It will create a single bundle out of
+// `test/browser.js and all files ending in `.spec.js` within the
+// `test` directory and all its subdirectories.
+'use strict'
+
+// Load test/browser.js if it exists
+try {
+  require(TEST_DIR + '/browser.js')
+} catch (_err) {
+  // Intentionally empty
+}
+
+const testsContext = require.context(TEST_DIR, true, /\.spec\.js$/)
+testsContext.keys().forEach(testsContext)

--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -19,9 +19,6 @@ module.exports = function (config) {
   config.set({
     frameworks: ['mocha'],
     basePath: process.cwd(),
-    preprocessors: {
-      'test/**/*.js': ['webpack', 'sourcemap']
-    },
     webpackMiddleware: {
       noInfo: true
     },

--- a/src/config/webpack/index.js
+++ b/src/config/webpack/index.js
@@ -15,6 +15,8 @@ function webpackConfig (env) {
     const libraryName = utils.getLibraryName(pkg.name)
     const userConfig = user.webpack
     const entry = user.entry
+    const environment = utils.getEnv(env).stringified
+    environment.TEST_DIR = JSON.stringify(path.join(process.cwd(), 'test'))
 
     return merge(base, {
       entry: [
@@ -27,7 +29,7 @@ function webpackConfig (env) {
         path: utils.getPathToDist()
       },
       plugins: [
-        new webpack.DefinePlugin(utils.getEnv(env).stringified)
+        new webpack.DefinePlugin(environment)
       ]
     }, userConfig)
   })

--- a/src/test/browser-config.js
+++ b/src/test/browser-config.js
@@ -14,8 +14,9 @@ function getPatterns (ctx) {
   }
 
   return [
-    'test/browser.js',
-    'test/**/*.spec.js'
+    // Karma needs a single entry point. That files will create a single bundle
+    // out of `test/browser.js` and `test/**/*.spec.js`
+    'node_modules/aegir/src/config/karma-webpack-bundle.js'
   ]
 }
 
@@ -47,6 +48,13 @@ function getConfig (isWebworker, ctx) {
     pattern: pattern,
     included: !isWebworker
   }))
+  // Preprocess every file that is used as a test file for Karma. By default
+  // that's a single entry point, but it could also be a single test that
+  // is given as command line parameter
+  const preprocessors = getPatterns(ctx).reduce((acc, pattern) => {
+    acc[pattern] = ['webpack', 'sourcemap']
+    return acc
+  }, {})
 
   const fixtureFiles = [{
     pattern: 'test/fixtures/**/*',
@@ -70,6 +78,7 @@ function getConfig (isWebworker, ctx) {
       frameworks: isWebworker ? ['mocha-webworker'] : ['mocha'],
       logLevel: ctx.verbose ? 'debug' : 'error',
       client: getClient(isWebworker, ctx),
+      preprocessors: preprocessors,
       mochaOwnReporter: {
         reporter: 'spec'
       },


### PR DESCRIPTION
Prior to this commit there was a webpack bundle created for every test
file. That lead to very high memory usage when running the Browser tests.
Now there's a single bundle.