### PR TITLE
fix: don't show warning if test/browser.js doesn't exist

### DIFF
--- a/src/config/karma-webpack-bundle.js
+++ b/src/config/karma-webpack-bundle.js
@@ -1,14 +1,12 @@
-/* global TEST_DIR */
+/* global TEST_DIR, TEST_BROWSER_JS */
 // This is webpack specific. It will create a single bundle out of
 // `test/browser.js and all files ending in `.spec.js` within the
 // `test` directory and all its subdirectories.
 'use strict'
 
 // Load test/browser.js if it exists
-try {
-  require(TEST_DIR + '/browser.js')
-} catch (_err) {
-  // Intentionally empty
+if (TEST_BROWSER_JS) {
+  require(TEST_BROWSER_JS)
 }
 
 const testsContext = require.context(TEST_DIR, true, /\.spec\.js$/)

--- a/src/config/webpack/index.js
+++ b/src/config/webpack/index.js
@@ -3,6 +3,7 @@
 const merge = require('webpack-merge')
 const webpack = require('webpack')
 const path = require('path')
+const fs = require('fs')
 
 const utils = require('../../utils')
 const base = require('./base')
@@ -16,7 +17,14 @@ function webpackConfig (env) {
     const userConfig = user.webpack
     const entry = user.entry
     const environment = utils.getEnv(env).stringified
-    environment.TEST_DIR = JSON.stringify(path.join(process.cwd(), 'test'))
+    const testDir = path.join(process.cwd(), 'test')
+    environment.TEST_DIR = JSON.stringify(testDir)
+    const browserJs = path.join(testDir, 'browser.js')
+    if (fs.existsSync(browserJs)) {
+      environment.TEST_BROWSER_JS = JSON.stringify(browserJs)
+    } else {
+      environment.TEST_BROWSER_JS = JSON.stringify('')
+    }
 
     return merge(base, {
       entry: [


### PR DESCRIPTION
Check if `test/browser.js` exist before webpack is initiated and require
it only if it really exist. This makes a warning go away that lead to
a lot of console output.

Fixes #204.