### PR TITLE
Make dist output usable directly by webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   "license": "MIT",
   "dependencies": {
     "async": "^2.6.0",
+    "babel-loader": "^7.1.4",
+    "babel-preset-es2015": "^6.24.1",
     "browserify-zlib": "^0.2.0",
     "chalk": "^2.3.0",
     "clean-documentation-theme": "^0.5.2",

--- a/src/config/webpack/index.js
+++ b/src/config/webpack/index.js
@@ -32,6 +32,14 @@ function webpackConfig (env) {
         entry
       ],
       devtool: sourcemap,
+      module: {
+        rules: [
+          {
+            test: /\.js$/,
+            loader: 'babel-loader'
+          }
+        ]
+      },
       output: {
         filename: path.basename(entry),
         library: libraryName,

--- a/src/config/webpack/index.js
+++ b/src/config/webpack/index.js
@@ -35,6 +35,7 @@ function webpackConfig (env) {
       output: {
         filename: path.basename(entry),
         library: libraryName,
+        libraryTarget: 'umd',
         path: utils.getPathToDist()
       },
       plugins: [


### PR DESCRIPTION
This PR comes from this issue : https://github.com/ipfs/aegir/issues/175

Webpack as configured by default by `create- react-app` for instance expects module to be already transpiled to ES5 and to actually export something (not just set a global variable).
From what I've read it's also considered best practice to always transpile distributed libraries to ES5. Regarding the modularization, ideally all tools would support ESM but I'm not sure that's the case right now so using CJS (via UMD) looks like a safe bet.
This should also be retro-compatible since with UMD, a global variable is also exposed.

With the current code, the way that would work, is that the built library would have to have a `.babelrc` file at its root for it to be transpiled.
- If you're ok keeping it that way then the `babel-preset-es2015` should probably be removed from here and be the responsability of the library to be built (since it could chose another preset).
- But you might think it's a bit awkward so we could decide to go the other way and force a preset upon the built libraries (`babel-preset-env` for instance) in the webpack config.

Let me know what you think!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ipfs/aegir/210)
<!-- Reviewable:end -->
