### PR TITLE
feat: add inline-source-map for webpack

### DIFF
--- a/src/config/webpack/index.js
+++ b/src/config/webpack/index.js
@@ -25,12 +25,13 @@ function webpackConfig (env) {
     } else {
       environment.TEST_BROWSER_JS = JSON.stringify('')
     }
+    const sourcemap = env === 'test' ? 'inline-source-map' : 'source-map'
 
     return merge(base, {
       entry: [
         entry
       ],
-      devtool: 'source-map',
+      devtool: sourcemap,
       output: {
         filename: path.basename(entry),
         library: libraryName,

--- a/test/config/webpack.spec.js
+++ b/test/config/webpack.spec.js
@@ -7,6 +7,7 @@ const mock = require('mock-require')
 describe('config - webpack', () => {
   afterEach(() => {
     mock.stop('../../src/utils')
+    mock.stop('../../src/config/user')
   })
 
   it('custom configs', () => {
@@ -50,6 +51,45 @@ describe('config - webpack', () => {
       expect(conf).to.have.deep.property('entry', ['src/main.js'])
       expect(conf).to.have.nested.property('output.library', 'Example')
       expect(conf).to.have.property('devtool', 'eval')
+    })
+  })
+
+  it('uses inline-source-map for test', () => {
+    mock('../../src/config/user', function () {
+      return {
+        webpack: {},
+        entry: ''
+      }
+    })
+    const config = mock.reRequire('../../src/config/webpack')
+    return config('test').then((webpack) => {
+      expect(webpack.devtool).to.equal('inline-source-map')
+    })
+  })
+
+  it('uses sourcemap for production', () => {
+    mock('../../src/config/user', function () {
+      return {
+        webpack: {},
+        entry: ''
+      }
+    })
+    const config = mock.reRequire('../../src/config/webpack')
+    return config('production').then((webpack) => {
+      expect(webpack.devtool).to.equal('source-map')
+    })
+  })
+
+  it('uses sourcemap as the default', () => {
+    mock('../../src/config/user', function () {
+      return {
+        webpack: {},
+        entry: ''
+      }
+    })
+    const config = mock.reRequire('../../src/config/webpack')
+    return config().then((webpack) => {
+      expect(webpack.devtool).to.equal('source-map')
     })
   })
 })


### PR DESCRIPTION
Uses inline-source-map for webpack when running the tests. This will
then give accurate line numbers for failing tests.