### PR TITLE
feat: enable uglify mangle and compress

### DIFF
--- a/src/build/browser.js
+++ b/src/build/browser.js
@@ -39,8 +39,8 @@ function minify (ctx, task) {
   return fs.readFile(path.join(process.cwd(), 'dist', 'index.js'))
     .then((code) => {
       const result = Uglify.minify(code.toString(), {
-        mangle: false,
-        compress: false
+        mangle: true,
+        compress: { unused: false }
       })
       if (result.error) {
         throw result.error


### PR DESCRIPTION
We can now enable **mangling** after changing the way we did some type checking, from comparing instances with `constructor.name` to using the [class-is](https://github.com/moxystudio/js-class-is) module that uses symbols, as proposed in https://github.com/ipfs/js-ipfs/issues/1131#issuecomment-373299739.

Check https://github.com/ipfs/js-ipfs/issues/938#issuecomment-377945902 for some of the repos that were affected.

We can now also **compress** the code, but I've had to disable the `unused` flag (it drops unreferenced functions and variables -- [check it](https://github.com/mishoo/UglifyJS2#compress-options)) due to the following error:
```js
Uncaught (in promise) Error: Callback was already called
```

Fixes https://github.com/ipfs/js-ipfs/issues/938.

