### PR TITLE
feat: Allow loading resources from hoisted dependencies

### DIFF
--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -1,0 +1,18 @@
+/* eslint-env mocha */
+'use strict'
+
+const loadFixture = require('../fixtures')
+const expect = require('chai').expect
+const path = require('path')
+
+describe('fixtures', () => {
+  it('should load fixtures from dependencies', () => {
+    const myFixture = loadFixture('package.json', 'mocha')
+    expect(JSON.parse(myFixture).name).to.be.eql('mocha')
+  })
+
+  it('should load local fixtures', () => {
+    const myFixture = loadFixture(path.join('test', 'fixtures', 'test.txt'))
+    expect(myFixture.toString('utf8').trim()).to.be.eql('Hello Fixture')
+  })
+})

--- a/test/fixtures/resolve-test/node_modules/dep-a/fixture.txt
+++ b/test/fixtures/resolve-test/node_modules/dep-a/fixture.txt
@@ -1,0 +1,1 @@
+Hi there

--- a/test/fixtures/resolve-test/project-dir/fixtures.spec.js
+++ b/test/fixtures/resolve-test/project-dir/fixtures.spec.js
@@ -1,0 +1,12 @@
+/* eslint-env mocha */
+'use strict'
+
+const loadFixture = require('aegir/fixtures')
+const expect = require('chai').expect
+
+describe('fixtures (require.resolve)', () => {
+  it('should use require.resolve to load fixtures from parent directories', () => {
+    const myFixture = loadFixture('fixture.txt', 'dep-a')
+    expect(myFixture.toString('utf8').trim()).to.be.eql('Hi there')
+  })
+})

--- a/test/fixtures/resolve-test/project-dir/node_modules/aegir/fixtures.js
+++ b/test/fixtures/resolve-test/project-dir/node_modules/aegir/fixtures.js
@@ -1,0 +1,11 @@
+/* eslint no-eval: 0 */
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const source = fs.readFileSync(path.resolve(path.join(__dirname, '..', '..', '..', '..', '..', '..', 'src', 'fixtures.js')))
+
+// the fixtures.js code tries to load files starting from it's location (e.g.
+// /src) so we use eval so the runtime will treat this as the starting point
+// for the require.resolve paths instead
+module.exports = eval(source.toString('utf8'))


### PR DESCRIPTION
The current implementation of `/src/fixtures.js` only takes a few paths into account when trying to load a fixture.  This PR adds using `require.resolve` to attempt to load a fixture too.

This is useful if you are running a monorepo and are using aegir to simplify your build process - in this case shared dependencies may have been be hoisted to a directory higher up the tree.  Trying to require fixtures using aegir fails at the moment when this is the case.