### PR TITLE
Add cobertura as a code coverage reporter

### DIFF
--- a/src/test/node.js
+++ b/src/test/node.js
@@ -64,7 +64,7 @@ function testNode (ctx) {
       coverageFiles,
       '--exclude',
       coverageFilesExclude.join(' '),
-      '--reporter=lcov', '--reporter=text',
+      '--reporter=lcov', '--reporter=text', '--reporter=cobertura',
       'mocha',
       `--timeout=${timeout}`
     ].concat(args)


### PR DESCRIPTION
Allows the jenkins plugin "cobertura" to log coverage history and show lines covered etc etc

Part of https://github.com/ipfs/wg-qa-testing-dx/issues/23