### PR TITLE
Force aegir/karma to exit after successful run

### DIFF
--- a/src/test/browser.js
+++ b/src/test/browser.js
@@ -10,9 +10,15 @@ function karma (config) {
     const server = new Server(config, (exitCode) => {
       if (exitCode > 0) {
         reject(new Error('Some tests are failing'))
-      }
+      } else {
+        resolve()
 
-      resolve()
+        // Force aegir/karma to exit after 1 second after test completion
+        // Issue: https://github.com/ampproject/amphtml/pull/14814
+        setTimeout(() => {
+          process.exit(0)
+        }, 1000)
+      }
     })
 
     server.start()


### PR DESCRIPTION
Karma has some issues letting go after the test run. Ref https://github.com/karma-runner/karma/issues/1788 and https://github.com/ampproject/amphtml/pull/14814

This fix basically forces aegir to close after the karma tests have been successfully run, so instead of a test-run taking 13 seconds for the tests to run then 30 seconds for karma to force-close, it finishes in 14 seconds. 

Solves https://github.com/ipfs/aegir/issues/212