### PR TITLE
Inline requires in CLI inclusions

### DIFF
--- a/cmds/build.js
+++ b/cmds/build.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const build = require('../src/build')
-const onError = require('../src/error-handler')
-
 module.exports = {
   command: 'build',
   desc: 'Build ready to release',
@@ -19,6 +16,8 @@ module.exports = {
     }
   },
   handler (argv) {
+    const build = require('../src/build')
+    const onError = require('../src/error-handler')
     build.run(argv).catch(onError)
   }
 }

--- a/cmds/coverage.js
+++ b/cmds/coverage.js
@@ -1,7 +1,5 @@
 'use strict'
-
 const coverage = require('../src/coverage')
-const onError = require('../src/error-handler')
 
 module.exports = {
   command: 'coverage',
@@ -49,6 +47,7 @@ module.exports = {
     }
   },
   handler (argv) {
+    const onError = require('../src/error-handler')
     coverage.run(argv).catch(onError)
   }
 }

--- a/cmds/docs.js
+++ b/cmds/docs.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const docs = require('../src/docs')
-const onError = require('../src/error-handler')
-
 module.exports = {
   command: 'docs',
   desc: 'Generate documentation using jsdoc',
@@ -21,6 +18,8 @@ module.exports = {
     }
   },
   handler (argv) {
+    const docs = require('../src/docs')
+    const onError = require('../src/error-handler')
     docs.run(argv).catch(onError)
   }
 }

--- a/cmds/lint.js
+++ b/cmds/lint.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const lint = require('../src/lint')
-const onError = require('../src/error-handler')
-
 module.exports = {
   command: 'lint',
   desc: 'Lint all project files',
@@ -14,6 +11,8 @@ module.exports = {
     }
   },
   handler (argv) {
+    const lint = require('../src/lint')
+    const onError = require('../src/error-handler')
     lint(argv).catch(onError)
   }
 }

--- a/cmds/release.js
+++ b/cmds/release.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const release = require('../src/release')
-const onError = require('../src/error-handler')
-
 module.exports = {
   command: 'release',
   desc: 'Release your code onto the world',
@@ -80,6 +77,8 @@ module.exports = {
     }
   },
   handler (argv) {
+    const release = require('../src/release')
+    const onError = require('../src/error-handler')
     release(argv).catch(onError)
   }
 }

--- a/cmds/test.js
+++ b/cmds/test.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const test = require('../src/test')
-const onError = require('../src/error-handler')
-
 module.exports = {
   command: 'test',
   desc: 'Test your code in different environments',
@@ -53,6 +50,8 @@ module.exports = {
     }
   },
   handler (argv) {
+    const test = require('../src/test')
+    const onError = require('../src/error-handler')
     test.run(argv).catch(onError)
   }
 }

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -1,29 +1,33 @@
 'use strict'
 
-const pmap = require('p-map')
-const _ = require('lodash')
-
-const node = require('./node')
-const browser = require('./browser')
-
-const userConfig = require('../config/user')
-
 const TASKS = [{
   title: 'Test Node.js',
-  task: node,
-  enabled: (ctx) => _.includes(ctx.target, 'node')
+  task: (opts) => {
+    const node = require('./node')
+    return node(opts)
+  },
+  enabled: (ctx) => ctx.target.includes('node')
 }, {
   title: 'Test Browser',
-  task: browser.default,
-  enabled: (ctx) => _.includes(ctx.target, 'browser')
+  task: (opts) => {
+    const browser = require('./browser')
+    return browser.default(opts)
+  },
+  enabled: (ctx) => ctx.target.includes('browser')
 }, {
   title: 'Test Webworker',
-  task: browser.webworker,
-  enabled: (ctx) => _.includes(ctx.target, 'webworker')
+  task: (opts) => {
+    const browser = require('./browser')
+    return browser.webworker(opts)
+  },
+  enabled: (ctx) => ctx.target.includes('webworker')
 }]
 
 module.exports = {
   run (opts) {
+    const userConfig = require('../config/user')
+    const pmap = require('p-map')
+
     opts.hooks = userConfig().hooks
     return pmap(TASKS, (task) => {
       if (!task.enabled(opts)) {


### PR DESCRIPTION
This makes the CLI a lot faster as aegir only have to load required commands
when it's actually needed, not always. Every command gets faster as well
since it only loads what needed (node tests don't need to load Karma
anymore for example)

This branch:
  `time node cli.js` => ~0.2 seconds
  `time node cli.js test` => ~1.6 seconds

Current master:
  `time node cli.js` => ~1.0 seconds
  `time node cli.js test` => ~2.1 seconds