### PR TITLE
Junit random suffix

### DIFF
--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -16,6 +16,9 @@ if (process.env.TRAVIS) {
 }
 
 module.exports = function (config) {
+  const randomNumber = Math.floor(Math.random() * 10000)
+  const junitFile = `junit-report-browser-${randomNumber}.xml`
+
   config.set({
     frameworks: ['mocha'],
     basePath: process.cwd(),
@@ -38,7 +41,7 @@ module.exports = function (config) {
     },
     junitReporter: {
       outputDir: process.cwd(),
-      outputFile: 'junit-report-browser.xml',
+      outputFile: junitFile,
       useBrowserName: false
     },
     port: 9876,

--- a/src/test/browser-config.js
+++ b/src/test/browser-config.js
@@ -69,6 +69,10 @@ function getConfig (isWebworker, ctx) {
     // no need for entry
     webpack.entry = ''
 
+    const randomNumber = Math.floor(Math.random() * 10000)
+    const testType = isWebworker ? 'webworker' : 'browser'
+    const junitFile = `junit-report-${testType}-${randomNumber}.xml`
+
     return _.defaultsDeep({
       files: ctxFiles.concat(fixtureFiles).concat(userFiles)
     }, userKarma, {
@@ -83,7 +87,7 @@ function getConfig (isWebworker, ctx) {
         reporter: 'spec'
       },
       junitReporter: {
-        outputFile: isWebworker ? 'junit-report-webworker.xml' : 'junit-report-browser.xml'
+        outputFile: junitFile
       },
       browserNoActivityTimeout: 50 * 1000,
       customLaunchers: {

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -45,7 +45,8 @@ function testNode (ctx) {
 
   if (process.env.CI) {
     args.push('--reporter=mocha-jenkins-reporter')
-    env.JUNIT_REPORT_PATH = path.join(process.cwd(), 'junit-report-node.xml')
+    const randomNumber = Math.floor(Math.random() * 10000)
+    env.JUNIT_REPORT_PATH = path.join(process.cwd(), `junit-report-node-${randomNumber}.xml`)
   }
 
   if (ctx.watch) {


### PR DESCRIPTION
This makes it so if we run many tests concurrently in CI, the test-reports will not overwrite each other.

Contains one revert that I will remove as soon as @achingbrain submitted a fix for the issue it introduced.