### PR TITLE
feat: add ability for user to configure linted files

### DIFF
--- a/src/lint.js
+++ b/src/lint.js
@@ -3,6 +3,7 @@
 const CLIEngine = require('eslint').CLIEngine
 const path = require('path')
 const formatter = CLIEngine.getFormatter()
+const userConfig = require('./config/user')
 
 const CONFIG_FILE = path.resolve(__dirname, 'config', 'eslintrc.yml')
 
@@ -78,7 +79,9 @@ function runLinter (opts = {}) {
       fix: opts.fix
     })
 
-    const report = cli.executeOnFiles(FILES)
+    const config = userConfig()
+    const files = (config.lint && config.lint.files) || FILES
+    const report = cli.executeOnFiles(files)
 
     console.log(formatter(report.results))
 

--- a/test/lint.spec.js
+++ b/test/lint.spec.js
@@ -115,4 +115,38 @@ describe('lint', () => {
       'some-dep': '<1.0.0'
     })
   })
+
+  it('should pass in user defined path globs', () => {
+    return setupProjectWithDeps([])
+      .then(() => {
+        // Directory not included in the default globs
+        const dir = `test-${Date.now()}`
+
+        fs.mkdirSync(dir)
+        fs.writeFileSync(`${dir}/test.js`, `'use strict'\n\nmodule.exports = {}\n`)
+        fs.writeFileSync(
+          '.aegir.js',
+          `module.exports = { lint: { files: ['${dir}/*.js'] } }`
+        )
+      })
+      .then(() => lint())
+  })
+
+  it('should fail in user defined path globs', () => {
+    return setupProjectWithDeps([])
+      .then(() => {
+        // Directory not included in the default globs
+        const dir = `test-${Date.now()}`
+
+        fs.mkdirSync(dir)
+        fs.writeFileSync(`${dir}/test.js`, `() .> {`)
+        fs.writeFileSync(
+          '.aegir.js',
+          `module.exports = { lint: { files: ['${dir}/*.js'] } }`
+        )
+      })
+      .then(() => lint())
+      .then(() => { throw new Error('Should have failed!') })
+      .catch(error => expect(error.message).to.contain('Lint errors'))
+  })
 })


### PR DESCRIPTION
Currently the lint task for `interface-ipfs-core` is passing because the [default globs](https://github.com/ipfs/aegir/blob/46ba7165666a1034f01b82bca63517698da8701b/src/lint.js#L9-L19) do not include the `js/` prefix. This PR allows the user to configure the globs for files that should be linted.