### PR TITLE
docs: instruction on how to get webpack stats data

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ Webpack will use the specified file as the entry point and output it to `dist/<f
 
 If `.aegir.js` file is not present in the project, webpack will use `src/index.js` as the default entry file.
 
+#### Generating Webpack stats.json
+
+Pass the `--stats` option to have Webpack generate a `stats.json` file for the bundle and save it in the project root (see https://webpack.js.org/api/stats/). e.g.
+
+```bash
+aegir build --stats
+```
+
 ### Releasing
 
 1. Run linting


### PR DESCRIPTION
For passing to a bundle visualizer like https://chrisbateman.github.io/webpack-visualizer/