### PR TITLE
feat: add support for eslint overrides

### DIFF
--- a/src/lint.js
+++ b/src/lint.js
@@ -75,7 +75,7 @@ function runLinter (opts = {}) {
   return new Promise((resolve, reject) => {
     const cli = new CLIEngine({
       useEslintrc: true,
-      configFile: CONFIG_FILE,
+      baseConfig: require('./config/eslintrc'),
       fix: opts.fix
     })
 

--- a/src/lint.js
+++ b/src/lint.js
@@ -5,8 +5,6 @@ const path = require('path')
 const formatter = CLIEngine.getFormatter()
 const userConfig = require('./config/user')
 
-const CONFIG_FILE = path.resolve(__dirname, 'config', 'eslintrc.js')
-
 const FILES = [
   '*.js',
   'bin/**',


### PR DESCRIPTION
This PR adds support to override eslint config with a .eslintrc.* file or an eslintConfig field in a package.json file. 

Basically using `configFile` with `useEslintrc: true` doesn't work because `configFile` takes precedence over anything coming from the current repo. 

/cc @PedroMiguelSS, @diasdavid 