### PR TITLE
feat: add grep and colors option to test

### DIFF
--- a/cmds/test.js
+++ b/cmds/test.js
@@ -38,8 +38,17 @@ module.exports = {
       default: 5000
     },
     exit: {
-      describe: 'force shutdown of the event loop after test run: mocha will call process.exit',
+      describe: 'Force shutdown of the event loop after test run: mocha will call process.exit',
       default: true
+    },
+    colors: {
+      describe: 'Enable colors on output (only available in node runs)',
+      default: true
+    },
+    grep: {
+      alias: 'g',
+      type: 'string',
+      describe: 'Limit tests to those whose names match given pattern',
     },
     cors: {
       describe: 'Enable or disable CORS (only available in browser runs)',

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "lint": "node cli.js lint",
-    "test:node": "cross-env AEGIR_TEST=hello node cli.js test -t node",
+    "test:node": "cross-env AEGIR_TEST=hello node cli.js test -t node --files 'test/**/*.spec.js'",
     "test:browser": "cross-env AEGIR_TEST=hello node cli.js test -t browser webworker --files test/browser.spec.js",
     "test": "npm run test:node && npm run test:browser",
     "coverage": "cross-env AEGIR_TEST=hello node cli.js coverage -t node",

--- a/src/test/browser-config.js
+++ b/src/test/browser-config.js
@@ -20,26 +20,23 @@ function getPatterns (ctx) {
   ]
 }
 
-function webworkerClient (ctx) {
-  return {
-    mochaWebWorker: {
-      pattern: getPatterns(ctx),
-      mocha: {
-        timeout: ctx.timeout
+function getClient (isWebworker, ctx) {
+  const client = {
+    timeout: ctx.timeout
+  }
+  if (ctx.grep) {
+    client.grep = ctx.grep
+  }
+  if (isWebworker) {
+    return {
+      mochaWebWorker: {
+        pattern: getPatterns(ctx),
+        mocha: client
       }
     }
   }
-}
-
-function getClient (isWebworker, ctx) {
-  if (isWebworker) {
-    return webworkerClient(ctx)
-  }
-
   return {
-    mocha: {
-      timeout: ctx.timeout
-    }
+    mocha: client
   }
 }
 

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -25,14 +25,23 @@ function testNode (ctx) {
   }
 
   let args = [
-    '--ui', 'bdd',
-    '--colors'
+    '--ui', 'bdd'
   ]
 
   let files = [
     'test/node.js',
     'test/**/*.spec.js'
   ]
+
+  if (ctx.colors) {
+    args.push('--colors')
+  } else {
+    args.push('--no-colors')
+  }
+
+  if (ctx.grep) {
+    args.push(`--grep=${ctx.grep}`)
+  }
 
   if (ctx.files && ctx.files.length > 0) {
     files = ctx.files

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,6 +82,7 @@ exports.getUserConfig = () => {
   try {
     conf = require(exports.getUserConfigPath())
   } catch (err) {
+    // Ignored
   }
   return conf
 }


### PR DESCRIPTION
Also specify files to run for node tests, as there is no test/node.js or test/**/*.spec.js
files.

The output for tests on some color setups is unreadable, disabling
colors helps this immensely.

As I started to bring up in
 https://github.com/ipfs/interface-ipfs-core/issues/325, there isn't a
clean way to isolate tests built into the setup currently. Adding the
grep option gives this to us.