### PR TITLE
fix: remove git-validate until it can be a subdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "findup-sync": "^2.0.0",
     "fs-extra": "^4.0.3",
     "gh-pages": "^1.1.0",
-    "git-validate": "^2.2.2",
     "glob": "^7.1.2",
     "joi": "^13.0.2",
     "json-loader": "~0.5.7",


### PR DESCRIPTION
@VictorBjelkholm @vmx @alanshaw e al, based on #251, can we remove git-validate until we know it works flawlessly?

We should have tests for this.