### PR TITLE
fix: make AEgir upgrade smoother

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "findup-sync": "^2.0.0",
     "fs-extra": "^4.0.3",
     "gh-pages": "^1.1.0",
-    "git-validate": "^2.2.2",
+    "git-validate": "^2.2.3",
     "glob": "^7.1.2",
     "joi": "^13.0.2",
     "json-loader": "~0.5.7",


### PR DESCRIPTION
With the change from `pre-push` to `git-validate` there was an issue
when you were removing `node_modules` before upgrading to AEgir 15.0.0.
(see https://github.com/ipfs/js-ipfs/issues/1444 for more).

On the most recent version of git-validate that issue was fixed.