### PR TITLE
[Making aegir smaller] Add support for pkg/pkg-bundle

### DIFF
--- a/.pkg.js
+++ b/.pkg.js
@@ -1,0 +1,5 @@
+'use strict'
+
+// Stub file so pkg-bundle imports these modules
+
+require('eslint-config-standard')

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "aegir": "cli.js"
   },
   "pkg": {
-    "scripts": ["cmds/*.js", "node_modules/coveralls/lib/**/*.js", "src/config/**/*.js", "node_modules/.bin/**", ".pkg.js"],
+    "scripts": ["cmds/*.js", "node_modules/coveralls/lib/**/*.js", "src/config/**/*.js", "node_modules/.bin/**", ".pkg.js", "node_modules/worker-farm/lib/child/index.js"],
     "assets": ["node_modules/eslint-*/**/*"]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "aegir": "cli.js"
   },
   "pkg": {
-    "scripts": ["cmds/*.js", "node_modules/coveralls/lib/**/*.js", "src/config/**/*.js", "node_modules/.bin/**"]
+    "scripts": ["cmds/*.js", "node_modules/coveralls/lib/**/*.js", "src/config/**/*.js", "node_modules/.bin/**", ".pkg.js"]
   },
   "scripts": {
     "lint": "node cli.js lint",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "bin": {
     "aegir": "cli.js"
   },
+  "pkg": {
+    "scripts": ["cmds/*.js", "node_modules/coveralls/lib/**/*.js", "src/config/**/*.js", "node_modules/.bin/**"]
+  },
   "scripts": {
     "lint": "node cli.js lint",
     "test:node": "cross-env AEGIR_TEST=hello node cli.js test -t node --files 'test/**/*.spec.js'",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "aegir": "cli.js"
   },
   "pkg": {
-    "scripts": ["cmds/*.js", "node_modules/coveralls/lib/**/*.js", "src/config/**/*.js", "node_modules/.bin/**", ".pkg.js"]
+    "scripts": ["cmds/*.js", "node_modules/coveralls/lib/**/*.js", "src/config/**/*.js", "node_modules/.bin/**", ".pkg.js"],
+    "assets": ["node_modules/eslint-*/**/*"]
   },
   "scripts": {
     "lint": "node cli.js lint",


### PR DESCRIPTION
This adds the missing pkg.scripts field to allow aegir to be bundled using pkg/pkg-bundle which is part of #215.
This is part of an effort to write https://github.com/mkg20001/aegir-bundle which depends on writing https://github.com/mkg20001/pkg-bundle
Note: Currently WIP, the CLI isn't working properly yet.

Commands that work:
 - [ ] `aegir build` https://github.com/mkg20001/aegir-bundle/issues/4
 - [ ] `aegir coverage` https://github.com/mkg20001/aegir-bundle/issues/5
 - [x] `aegir docs` 
 - [x] `aegir lint-commits`
 - [ ] `aegir lint` https://github.com/mkg20001/aegir-bundle/issues/6
 - [ ] `aegir release`
 - [ ] `aegir test` https://github.com/mkg20001/aegir-bundle/issues/7
