### PR TITLE
remove requirement to include @returns in jsdoc

### DIFF
--- a/src/config/eslintrc.js
+++ b/src/config/eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     'max-nested-callbacks': [2, 4],
     'max-depth': [2, 4],
     'valid-jsdoc': [2, {
+      requireReturn: false,
       requireParamDescription: false,
       requireReturnDescription: false
     }]


### PR DESCRIPTION
This PR only removes the requirement when the function doesn't actually return  like when using callbacks.
 
check this https://eslint.org/docs/rules/valid-jsdoc#options

option description

> "requireReturn" requires a return tag:
> true (default) even if the function or method does not have a return statement (this option value does not apply to constructors)
> false if and only if the function or method has a return statement or returns a value e.g. async function (this option value does apply to constructors)
