### PR TITLE
fix: windows takes 2 minutes to exit

### DIFF
--- a/src/test/browser.js
+++ b/src/test/browser.js
@@ -7,13 +7,9 @@ const utils = require('../utils')
 
 function karma (config) {
   return new Promise((resolve, reject) => {
-    const server = new Server(config, (exitCode) => {
-      if (exitCode > 0) {
-        reject(new Error('Some tests are failing'))
-      }
+    const server = new Server(config)
 
-      resolve()
-    })
+    server.once('exit', force => force(resolve))
 
     server.start()
   })


### PR DESCRIPTION
Fix for https://github.com/ipfs/aegir/issues/212

Doesn't leave any browsers around (they already exited at this point anyways)

@dignifiedquire can you review this?

License: MIT
Signed-off-by: Victor Bjelkholm <git@victor.earth>