### PR TITLE
feat: set browsers with AEGIR_BROWSERS

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "node cli.js lint",
     "test:node": "cross-env AEGIR_TEST=hello node cli.js test -t node --files 'test/**/*.spec.js'",
     "test:browser": "cross-env AEGIR_TEST=hello node cli.js test -t browser webworker --files test/browser.spec.js",
+    "test:cross-browser": "cross-env AEGIR_TEST=hello AEGIR_BROWSERS='Firefox,Chrome' npm run test:browser",
     "test": "npm run test:node && npm run test:browser",
     "coverage": "cross-env AEGIR_TEST=hello node cli.js coverage -t node",
     "watch": "cross-env AEGIR_TEST=hello node cli.js test -t node --watch",

--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -15,6 +15,15 @@ if (process.env.TRAVIS) {
   browsers.push('ChromeCustom')
 }
 
+const browsersEnv = process.env.AEGIR_BROWSERS
+if (browsersEnv) {
+  if (browsersEnv.indexOf(',') !== -1) {
+    browsers = browsersEnv.split(',')
+  } else {
+    browsers = [browsersEnv]
+  }
+}
+
 module.exports = function (config) {
   const randomNumber = Math.floor(Math.random() * 10000)
   const junitFile = `junit-report-browser-${randomNumber}.xml`

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -58,16 +58,10 @@ describe('utils', () => {
     process.env.AEGIR_TEST = 'hello'
 
     const env = utils.getEnv()
-    expect(env.raw).to.eql({
-      NODE_ENV: 'test',
-      AEGIR_TEST: 'hello'
-    })
-    expect(env.stringified).to.eql({
-      'process.env': {
-        NODE_ENV: '"test"',
-        AEGIR_TEST: '"hello"'
-      }
-    })
+    expect(env.raw.NODE_ENV).to.eql('test')
+    expect(env.raw.AEGIR_TEST).to.eql('hello')
+    expect(env.stringified['process.env'].NODE_ENV).to.eql('"test"')
+    expect(env.stringified['process.env'].AEGIR_TEST).to.eql('"hello"')
 
     process.env.NODE_ENV = ''
     expect(utils.getEnv('production').raw).to.have.property('NODE_ENV', 'production')


### PR DESCRIPTION
Accepts a comma-separated list of browsers or just one browser without
any commas.

Example to run in Chrome + Firefox

```console
AEGIR_BROWSERS='Firefox,Chrome' npm run test:browser
```

Fixes https://github.com/ipfs/aegir/issues/124

License: MIT
Signed-off-by: Victor Bjelkholm <git@victor.earth>