### PR TITLE
fix: fix documentation.js not loading files and change input file

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "conventional-github-releaser": "^2.0.0",
     "del": "^3.0.0",
     "detect-node": "^2.0.4",
-    "documentation": "^8.1.2",
+    "documentation": "^9.0.0-alpha.1",
     "es6-promisify": "^6.0.1",
     "eslint": "^4.19.0",
     "eslint-config-standard": "^11.0.0",

--- a/src/docs/build.js
+++ b/src/docs/build.js
@@ -1,9 +1,7 @@
 'use strict'
 
-const documentation = require('documentation')
-const glob = require('glob')
+const documentation = require('@hugomrdias/documentation')
 const fs = require('fs-extra')
-const pify = require('pify')
 const chalk = require('chalk')
 const vinyl = require('vinyl-fs')
 const streamArray = require('stream-array')
@@ -57,14 +55,9 @@ function writeMdDocs (output) {
 }
 
 function build (ctx) {
-  return Promise.all([
-    utils.getPkg(),
-    pify(glob)('./src/**/*.js', {
-      cwd: process.cwd()
-    })
-  ]).then((res) => {
-    const pkg = res[0]
-    const files = res[1]
+  return  utils.getPkg()
+  .then((pkg) => {
+    const files = './src/index.js'
 
     return Promise.all(ctx.docsFormats.map((fmt) => {
       if (fmt === 'md') {

--- a/src/docs/build.js
+++ b/src/docs/build.js
@@ -55,27 +55,27 @@ function writeMdDocs (output) {
 }
 
 function build (ctx) {
-  return  utils.getPkg()
-  .then((pkg) => {
-    const files = './src/index.js'
+  return utils.getPkg()
+    .then((pkg) => {
+      const files = './src/index.js'
 
-    return Promise.all(ctx.docsFormats.map((fmt) => {
-      if (fmt === 'md') {
-        return documentation.build(files, getOpts(pkg))
-          .then((docs) => documentation.formats.md(docs))
-          .then(writeMdDocs)
-      }
-      if (fmt === 'html') {
-        return documentation.build(files, getOpts(pkg))
-          .then((docs) => documentation.formats.html(docs, {
-            theme: require.resolve('clean-documentation-theme'),
-            version: pkg.version,
-            name: pkg.name
-          }))
-          .then(writeDocs)
-      }
-    }))
-  })
+      return Promise.all(ctx.docsFormats.map((fmt) => {
+        if (fmt === 'md') {
+          return documentation.build(files, getOpts(pkg))
+            .then((docs) => documentation.formats.md(docs))
+            .then(writeMdDocs)
+        }
+        if (fmt === 'html') {
+          return documentation.build(files, getOpts(pkg))
+            .then((docs) => documentation.formats.html(docs, {
+              theme: require.resolve('clean-documentation-theme'),
+              version: pkg.version,
+              name: pkg.name
+            }))
+            .then(writeDocs)
+        }
+      }))
+    })
 }
 
 module.exports = build

--- a/src/docs/build.js
+++ b/src/docs/build.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const documentation = require('@hugomrdias/documentation')
+const documentation = require('documentation')
 const fs = require('fs-extra')
 const chalk = require('chalk')
 const vinyl = require('vinyl-fs')
@@ -22,6 +22,7 @@ function generateDescription (pkg) {
 
 function getOpts (pkg) {
   const opts = {
+    resolve: 'node',
     github: true
   }
   const configFile = utils.getPathToDocsConfig()


### PR DESCRIPTION
documentation.js uses a browser specific resolve algo so with stuff like this

```
  "browser": {
    "hapi": false,
    "glob": false,
    "fs": false,
    "joi": false,
    "stream": "readable-stream",
    "http": "stream-http",
    "./src/utils/repo/nodejs.js": "./src/utils/repo/browser.js",
    "./src/utils/exec.js": false,
    "./src/utils/find-ipfs-executable.js": false,
    "./src/utils/tmp-dir.js": "./src/utils/tmp-dir-browser.js",
    "./src/utils/run.js": false,
    "./src/factory-daemon.js": false,
    "./src/ipfsd-daemon.js": false,
    "./src/endpoint/server.js": false,
    "./src/endpoint/routes.js": false,
    "./test/utils/df-config-nodejs.js": "./test/utils/df-config-browser.js"
  },
```

some files will not be found and no documentation generated.
With this PR i fix this with a fork of documentation.js that uses node resolve algo until we get support for this upstream https://github.com/documentationjs/documentation/issues/1143

This PR also changes input from  `**/*.js` to `./src/index.js` with this change documentation.js will walk deps starting from index.js and add everything required in the correct order. This makes the documentation much more intuitive 