### PR TITLE
[WIP] fix: unminified builds should not be minified

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "node cli.js lint",
     "test:node": "cross-env AEGIR_TEST=hello node cli.js test -t node --files 'test/**/*.spec.js'",
     "test:browser": "cross-env AEGIR_TEST=hello node cli.js test -t browser webworker --files test/browser.spec.js",
+    "test:acceptance": "./test/acceptance.sh",
     "test": "npm run test:node && npm run test:browser",
     "coverage": "cross-env AEGIR_TEST=hello node cli.js coverage -t node",
     "watch": "cross-env AEGIR_TEST=hello node cli.js test -t node --watch",

--- a/src/build/browser.js
+++ b/src/build/browser.js
@@ -35,23 +35,30 @@ function writeStats (ctx) {
 
 function minify (ctx, task) {
   const minifiedPath = path.join(process.cwd(), 'dist', 'index.min.js')
+  const mapPath = path.join(process.cwd(), 'dist', 'index.min.js.map')
 
   return fs.readFile(path.join(process.cwd(), 'dist', 'index.js'))
     .then((code) => {
       const result = Uglify.minify(code.toString(), {
         mangle: true,
-        compress: { unused: false }
+        compress: { unused: false },
+        sourceMap: {
+          filename: 'index.min.js',
+          url: 'index.min.js.map'
+        }
       })
       if (result.error) {
         throw result.error
       }
-      return result.code
+      return result
     })
-    .then((minified) => {
-      return fs.writeFile(
-        minifiedPath,
-        minified
-      )
+    .then(({code, map}) => {
+      return fs.writeFile(mapPath, map).then(() => {
+        return fs.writeFile(
+          minifiedPath,
+          code
+        )
+      })
     })
     .then(() => fs.stat(minifiedPath))
     .then((stats) => {

--- a/src/build/browser.js
+++ b/src/build/browser.js
@@ -13,7 +13,7 @@ const utils = require('../utils')
 const config = require('../config/webpack')
 
 function webpackBuild (ctx, task) {
-  return config().then((config) => {
+  return config('development').then((config) => {
     return pify(webpack)(config)
   }).then((stats) => {
     ctx.webpackResult = stats

--- a/src/config/webpack/index.js
+++ b/src/config/webpack/index.js
@@ -10,9 +10,23 @@ const utils = require('../../utils')
 const base = require('./base')
 const user = require('../user')()
 
-function webpackConfig (userEnv) {
-  const env = userEnv || 'production'
-  debug('Running webpack with userEnv', userEnv, 'ends up being', env)
+const devtool = {
+  'development': 'source-map',
+  'production': 'source-map',
+  'test': 'inline-source-map'
+}
+
+const getDevtool = (env) => {
+  const d = devtool[env]
+  if (!d) {
+    const jsonStr = JSON.stringify(devtool, null, 2)
+    throw new Error(`Could not find devtool for '${env}' in ${jsonStr}`)
+  }
+  return d
+}
+
+function webpackConfig (env) {
+  debug('Running webpack with env', env)
 
   return utils.getPkg().then((pkg) => {
     const libraryName = utils.getLibraryName(pkg.name)
@@ -27,14 +41,14 @@ function webpackConfig (userEnv) {
     } else {
       environment.TEST_BROWSER_JS = JSON.stringify('')
     }
-    const sourcemap = env === 'test' ? 'inline-source-map' : 'source-map'
 
+    const mode = env === 'production' ? 'production' : 'development'
     return merge(base, {
-      mode: env === 'production' ? 'production' : 'development',
+      mode: mode,
       entry: [
         entry
       ],
-      devtool: sourcemap,
+      devtool: getDevtool(env),
       output: {
         filename: path.basename(entry),
         library: libraryName,

--- a/src/config/webpack/index.js
+++ b/src/config/webpack/index.js
@@ -4,13 +4,15 @@ const merge = require('webpack-merge')
 const webpack = require('webpack')
 const path = require('path')
 const fs = require('fs')
+const debug = require('debug')('aegir:webpack')
 
 const utils = require('../../utils')
 const base = require('./base')
 const user = require('../user')()
 
-function webpackConfig (env) {
-  env = env || 'production'
+function webpackConfig (userEnv) {
+  const env = userEnv || 'production'
+  debug('Running webpack with userEnv', userEnv, 'ends up being', env)
 
   return utils.getPkg().then((pkg) => {
     const libraryName = utils.getLibraryName(pkg.name)

--- a/src/config/webpack/index.js
+++ b/src/config/webpack/index.js
@@ -11,9 +11,9 @@ const base = require('./base')
 const user = require('../user')()
 
 const devtool = {
-  'development': 'source-map',
-  'production': 'source-map',
-  'test': 'inline-source-map'
+  development: 'source-map',
+  production: 'source-map',
+  test: 'inline-source-map'
 }
 
 const getDevtool = (env) => {
@@ -27,6 +27,9 @@ const getDevtool = (env) => {
 
 function webpackConfig (env) {
   debug('Running webpack with env', env)
+  if (!env) {
+    throw new Error(`Missing argument 'env' when calling webpackConfig`)
+  }
 
   return utils.getPkg().then((pkg) => {
     const libraryName = utils.getLibraryName(pkg.name)

--- a/test/acceptance.sh
+++ b/test/acceptance.sh
@@ -1,0 +1,55 @@
+#! /usr/bin/env bash
+
+# Acceptance test for making sure aegir works as we want it to
+
+set -e
+
+# Debug
+# set -x
+
+echo "## Creating a link to current AEgir"
+npm link
+
+echo "## Creating test directory"
+TEST_DIR=$(mktemp -d)
+
+cd $TEST_DIR
+
+echo "## Cloning aegir-test-repo"
+git clone https://github.com/ipfs/aegir-test-repo
+
+cd aegir-test-repo
+
+echo "## Installing dependencies for aegir-test-repo"
+npm install
+
+echo "## Linking current AEgir into aegir-test-repo"
+npm link aegir
+
+echo "## Running build command"
+npm run build
+
+echo "## Making sure right files were created"
+
+if [ ! -d "dist" ]; then
+    echo "'dist/' directory wasn't created correctly "
+    exit 1
+fi
+
+if [ ! -e "dist/index.js" ]; then
+    echo "'dist/index.js' file wasn't created correctly "
+    exit 1
+fi
+
+if [ ! -e "dist/index.min.js" ]; then
+    echo "'dist/index.min.js' file wasn't created correctly "
+    exit 1
+fi
+
+if [ ! -e "dist/index.min.js.map" ]; then
+    echo "'dist/index.min.js.map' file wasn't created correctly "
+    exit 1
+fi
+
+echo "## Cleaning up"
+rm -rf $TEST_DIR

--- a/test/config/webpack.spec.js
+++ b/test/config/webpack.spec.js
@@ -47,7 +47,7 @@ describe('config - webpack', () => {
 
     const config = require('../../src/config/webpack')
 
-    return config().then((conf) => {
+    return config('test').then((conf) => {
       expect(conf).to.have.deep.property('entry', ['src/main.js'])
       expect(conf).to.have.nested.property('output.library', 'Example')
       expect(conf).to.have.property('devtool', 'eval')
@@ -80,7 +80,7 @@ describe('config - webpack', () => {
     })
   })
 
-  it('uses sourcemap as the default', () => {
+  it('fails if no env provided to webpack config', () => {
     mock('../../src/config/user', function () {
       return {
         webpack: {},
@@ -88,8 +88,27 @@ describe('config - webpack', () => {
       }
     })
     const config = mock.reRequire('../../src/config/webpack')
-    return config().then((webpack) => {
-      expect(webpack.devtool).to.equal('source-map')
+    try {
+      config()
+    } catch (err) {
+      expect(err.toString()).to.match(/missing argument/i)
+      expect(err.toString()).to.match(/env/i)
+      expect(err.toString()).to.match(/webpackConfig/i)
+    }
+  })
+  it('fails if unknown env provided to webpack config', () => {
+    mock('../../src/config/user', function () {
+      return {
+        webpack: {},
+        entry: ''
+      }
     })
+    const config = mock.reRequire('../../src/config/webpack')
+    try {
+      config('some-random-env')
+    } catch (err) {
+      expect(err.toString()).to.match(/some-random-env/i)
+      expect(err.toString()).to.match(/webpackConfig/i)
+    }
   })
 })


### PR DESCRIPTION
Setting the webpack mode to `production` seems to automatically minify
the source, so by explicitly setting it to `development`, we get a
unminified build and a minified one.

License: MIT
Signed-off-by: Victor Bjelkholm <git@victor.earth>