### PR TITLE
fix: bump version before building

### DIFF
--- a/src/release/index.js
+++ b/src/release/index.js
@@ -30,6 +30,10 @@ function release (opts) {
     task: (ctx) => test.run(ctx),
     enabled: (ctx) => ctx.test
   }, {
+    title: 'Bump Version',
+    task: bump,
+    enabled: (ctx) => ctx.bump
+  }, {
     title: 'Build',
     task: (ctx) => build(ctx),
     enabled: (ctx) => ctx.build
@@ -37,10 +41,6 @@ function release (opts) {
     title: 'Update Contributors',
     task: contributors,
     enabled: (ctx) => ctx.contributors
-  }, {
-    title: 'Bump Version',
-    task: bump,
-    enabled: (ctx) => ctx.bump
   }, {
     title: 'Generate Changelog',
     task: changelog,


### PR DESCRIPTION
Relatively straightforward change, makes `aegir release` do the bump
before the release.

Fixes #208

License: MIT
Signed-off-by: Victor Bjelkholm <git@victor.earth>