### PR TITLE
fix: dont require missing config

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -79,7 +79,9 @@ exports.getUserConfigPath = () => {
 exports.getUserConfig = () => {
   let conf = {}
   try {
-    conf = require(exports.getUserConfigPath())
+    const path = exports.getUserConfigPath()
+    if (!path) return null
+    conf = require(path)
   } catch (err) {
     console.error(err)
   }


### PR DESCRIPTION
The new version of aegir logs a `TypeError` whenever the `.aegir.js` file is missing for every command, which is very annoying. It doesn't break anything, just a UX issue.

This just makes sure we don't try to require the file if it doesn't exist.  I linked this to a couple of modules and ran `lint` and `test` commands to verify the fix.