### PR TITLE
chore: add eslint plugin react

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-standard": "^3.1.0",
     "execa": "^1.0.0",
     "filesize": "^3.6.1",
@@ -149,7 +150,6 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "cross-env": "^5.2.0",
-    "eslint-plugin-react": "^7.11.1",
     "mock-require": "^3.0.2",
     "sinon": "^7.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "cross-env": "^5.2.0",
+    "eslint-plugin-react": "^7.11.1",
     "mock-require": "^3.0.2",
     "sinon": "^7.1.0"
   },


### PR DESCRIPTION
Adding `eslint-plugin-react` so that aegir can be used with react projects. 

Note: this issue is currently making `js-ipfs` linting job red