### PR TITLE
chore: remove examples from linting

### DIFF
--- a/src/lint.js
+++ b/src/lint.js
@@ -14,7 +14,6 @@ const FILES = [
   'test/**/*.js',
   'src/**/*.js',
   'tasks/**/*.js',
-  'examples/**/*.js',
   'benchmarks/**/*.js',
   '!**/node_modules/**'
 ]


### PR DESCRIPTION
In the context of this discussion thread [js-ipfs#1678#pullrequestreview-169411876](https://github.com/ipfs/js-ipfs/pull/1678#pullrequestreview-169411876). 

Examples should have their own linting.