### PR TITLE
feat: change linting rules to make `console.foo` an error

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -37,19 +37,19 @@ cli.env('AEGIR')
 const args = cli.fail((msg, err, yargs) => {
   if (msg) {
     yargs.showHelp()
-    console.error(chalk.red(msg))
+    console.error(chalk.red(msg)) // eslint-disable-line no-console
   }
 
   if (err) {
-    console.error(chalk.red(err.message))
+    console.error(chalk.red(err.message)) // eslint-disable-line no-console
 
     if (args.debug) {
       // errors from execa output the child_process stderr
       if (err && err.stderr) {
-        console.error('Error running command: ', err.cmd, '\n')
-        console.error(err.stderr)
+        console.error('Error running command: ', err.cmd, '\n') // eslint-disable-line no-console
+        console.error(err.stderr) // eslint-disable-line no-console
       } else {
-        console.error(chalk.gray(err.stack))
+        console.error(chalk.gray(err.stack)) // eslint-disable-line no-console
       }
     }
   }

--- a/src/config/eslintrc.js
+++ b/src/config/eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
     'linebreak-style': [1, 'unix'],
     'no-alert': 2,
     'no-case-declarations': 2,
-    'no-console': 1,
+    'no-console': 2,
     'no-constant-condition': 2,
     'no-continue': 1,
     'no-div-regex': 2,

--- a/src/docs/build.js
+++ b/src/docs/build.js
@@ -14,7 +14,7 @@ function generateDescription (pkg) {
   try {
     example = fs.readFileSync(utils.getPathToExample())
   } catch (err) {
-    console.log(chalk.yellow('Warning: No `example.js` found in the root directory.'))
+    console.log(chalk.yellow('Warning: No `example.js` found in the root directory.')) // eslint-disable-line no-console
   }
 
   return introTmpl(pkg.name, pkg.repository.url, example)

--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -7,8 +7,8 @@ function onError (err) {
     return
   }
 
-  console.log(chalk.red(err.message))
-  console.log(chalk.gray(err.stack))
+  console.log(chalk.red(err.message)) // eslint-disable-line no-console
+  console.log(chalk.gray(err.stack)) // eslint-disable-line no-console
   process.exit(1)
 }
 

--- a/src/lint.js
+++ b/src/lint.js
@@ -59,7 +59,7 @@ function checkDependencyVersions () {
 
     if (badVersions.length) {
       badVersions.forEach(({ type, name, version, message }) => {
-        console.log(`${type} ${name} had version ${version} - ${message}`)
+        console.log(`${type} ${name} had version ${version} - ${message}`) // eslint-disable-line no-console
       })
 
       return reject(new Error('Dependency version errors'))
@@ -82,7 +82,7 @@ function runLinter (opts = {}) {
     const files = await globby(patterns)
     const report = cli.executeOnFiles(files)
 
-    console.log(formatter(report.results))
+    console.log(formatter(report.results)) // eslint-disable-line no-console
 
     if (report.errorCount > 0) {
       return reject(new Error('Lint errors'))

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -27,7 +27,7 @@ module.exports = {
         return Promise.resolve()
       }
 
-      console.log(task.title)
+      console.log(task.title) // eslint-disable-line no-console
       return task.task(opts)
     }, { concurrency: 1 })
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -85,7 +85,7 @@ exports.getUserConfig = () => {
     if (!path) return null
     conf = require(path)
   } catch (err) {
-    console.error(err)
+    console.error(err) // eslint-disable-line no-console
   }
   return conf
 }


### PR DESCRIPTION
Possibly contentious change.

Since we have the `debug` module, we generally don't need to use `console.log` and friends. It's useful during local debugging but it's also easy to forget to remove those lines so we could upgrade this to be an error to help ourselves out.

If you find that do need to use it (e.g. for cli output), you can easily disable the rule for that line with:

```javascript
console.info('Greetings Professor Falken') // eslint-disable-line no-console
```