### PR TITLE
feat: add rule to catch `.only` in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint": "^5.9.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-no-only-tests": "^2.0.1",
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",

--- a/src/config/eslintrc.js
+++ b/src/config/eslintrc.js
@@ -8,6 +8,9 @@ module.exports = {
   globals: {
     self: true
   },
+  plugins: [
+    'no-only-tests'
+  ],
   rules: {
     strict: [2, 'safe'],
     curly: 'error',
@@ -30,6 +33,7 @@ module.exports = {
     'no-labels': 2,
     'no-loop-func': 2,
     'no-nested-ternary': 1,
+    'no-only-tests/no-only-tests': 2,
     'no-script-url': 2,
     'no-warning-comments': 1,
     'quote-props': [2, 'as-needed'],


### PR DESCRIPTION
We've all done this. Committed a `.only` in a test file and wondered why the build was so fast. Or had a reviewer helpfully point out why the coverage has dropped so dramatically.