### PR TITLE
fix: make babel and webpack safer and faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "simple-git": "^1.105.0",
     "stats-webpack-plugin": "~0.7.0",
     "stream-http": "^3.0.0",
+    "terser-webpack-plugin": "^1.1.0",
     "through": "^2.3.8",
     "transform-loader": "~0.2.4",
     "uglify-es": "^3.3.9",

--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -36,23 +36,16 @@ module.exports = function (api, opts = {}) {
   return {
     presets: [
       isEnvTest && [
-        // ES features necessary for user's Node version
         require('@babel/preset-env').default,
         {
           targets: {
-            node: '8.11'
+            node: 'current'
           }
         }
       ],
       (isEnvProduction || isEnvDevelopment) && [
-        // Latest stable ECMAScript features
         require('@babel/preset-env').default,
         {
-          // `entry` transforms `@babel/polyfill` into individual requires for
-          // the targeted browsers. This is safer than `usage` which performs
-          // static code analysis to determine what's required.
-          // This is probably a fine default to help trim down bundles when
-          // end-users inevitably import '@babel/polyfill'.
           useBuiltIns: 'entry',
           modules: 'commonjs',
           targets

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -160,8 +160,8 @@ module.exports = (env, argv) => {
         base(env, argv),
         {
           output: {
-            filename: `${pkg.name}.js`,
-            sourceMapFilename: `${pkg.name}.js.map`
+            filename: 'index.js',
+            sourceMapFilename: 'index.js.map'
           },
           optimization: {
             minimize: false

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -5,13 +5,14 @@ const webpack = require('webpack')
 const merge = require('webpack-merge')
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 const StatsPlugin = require('stats-webpack-plugin')
+const TerserPlugin = require('terser-webpack-plugin')
 const { fromRoot, pkg, paths, getLibraryName } = require('../utils')
 const userConfig = require('./user')()
 const isProduction = process.env.NODE_ENV === 'production'
 
 const base = (env, argv) => {
   const filename = [
-    pkg.name,
+    'index',
     isProduction ? '.min' : null,
     '.js'
   ]
@@ -24,7 +25,6 @@ const base = (env, argv) => {
     devtool: isProduction ? 'source-map' : 'cheap-module-source-map',
     entry: [userConfig.entry],
     output: {
-      pathinfo: !isProduction,
       path: fromRoot(paths.dist),
       filename: filename,
       sourceMapFilename: filename + '.map',
@@ -36,25 +36,77 @@ const base = (env, argv) => {
     module: {
       rules: [
         {
-          test: /\.js$/,
-          use: {
-            loader: require.resolve('babel-loader'),
-            options: {
-              presets: [require('./babelrc')],
-              babelrc: false,
-              cacheDirectory: true
+          oneOf: [
+            {
+              test: /\.js$/,
+              include: fromRoot(paths.src),
+              use: {
+                loader: require.resolve('babel-loader'),
+                options: {
+                  presets: [require('./babelrc')],
+                  babelrc: false,
+                  cacheDirectory: true
+                }
+              }
+            },
+            {
+              test: /\.js$/,
+              exclude: /@babel(?:\/|\\{1,2})runtime/,
+              use: {
+                loader: require.resolve('babel-loader'),
+                options: {
+                  presets: [require('./babelrc')],
+                  babelrc: false,
+                  cacheDirectory: true,
+                  sourceMaps: false
+                }
+              }
             }
-          }
+          ]
         }
       ]
     },
-
     resolve: {
       alias: {
         '@babel/runtime': path.dirname(
           require.resolve('@babel/runtime/package.json')
         )
       }
+    },
+    optimization: {
+      minimize: isProduction,
+      minimizer: [
+        // This is only used in production mode
+        new TerserPlugin({
+          terserOptions: {
+            parse: {
+              // we want terser to parse ecma 8 code. However, we don't want it
+              // to apply any minfication steps that turns valid ecma 5 code
+              // into invalid ecma 5 code. This is why the 'compress' and 'output'
+              // sections only apply transformations that are ecma 5 safe
+              // https://github.com/facebook/create-react-app/pull/4234
+              ecma: 8
+            },
+            compress: {
+              ecma: 5,
+              warnings: false
+            },
+            mangle: {
+              safari10: true
+            },
+            output: {
+              ecma: 5,
+              comments: false
+            }
+          },
+          // Use multi-process parallel running to improve the build speed
+          // Default number of concurrent runs: os.cpus().length - 1
+          parallel: true,
+          // Enable file caching
+          cache: true,
+          sourceMap: true
+        })
+      ]
     },
     plugins: [
       new webpack.DefinePlugin({
@@ -64,6 +116,11 @@ const base = (env, argv) => {
     ],
     target: 'web',
     node: {
+      dgram: 'empty',
+      fs: 'empty',
+      net: 'empty',
+      tls: 'empty',
+      child_process: 'empty',
       console: false,
       global: true,
       process: true,
@@ -107,7 +164,7 @@ module.exports = (env, argv) => {
             sourceMapFilename: `${pkg.name}.js.map`
           },
           optimization: {
-            minimizer: []
+            minimize: false
           }
         },
         external

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,9 +18,11 @@ const { pkg, path: pkgPath } = readPkgUp.sync({
 })
 const PKG_FILE = 'package.json'
 const DIST_FOLDER = 'dist'
+const SRC_FOLDER = 'src'
 
 exports.paths = {
-  dist: DIST_FOLDER
+  dist: DIST_FOLDER,
+  src: SRC_FOLDER
 }
 exports.pkg = pkg
 exports.hasPkgProp = props => arrify(props).some(prop => _.has(pkg, prop))


### PR DESCRIPTION
This PR makes  experimental babel/webpack config safer, faster and more compatible with the default one and bundle smaller.