### PR TITLE
feat: add checks for dependencies

### DIFF
--- a/cmds/dependency-check.js
+++ b/cmds/dependency-check.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = {
+  command: 'dependency-check',
+  desc: 'Checks is there are missing or extra dependencies defined',
+  handler (argv) {
+    const dependencyCheck = require('../src/dependency-check')
+    return dependencyCheck(argv)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "conventional-changelog": "^2.0.3",
     "conventional-github-releaser": "^2.0.0",
     "del": "^3.0.0",
+    "dependency-check": "^3.2.1",
     "detect-node": "^2.0.4",
     "documentation": "^9.0.0-alpha.1",
     "es6-promisify": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "lint",
     "build"
   ],
+  "aegir": {
+    "dependencyCheck": {
+      "additionalEntryPoints": ["./cmds/**/*"]
+    }
+  },
   "homepage": "https://github.com/ipfs/aegir",
   "bugs": "https://github.com/ipfs/aegir/issues",
   "license": "MIT",
@@ -64,6 +69,7 @@
     "del": "^3.0.0",
     "dependency-check": "^3.2.1",
     "detect-node": "^2.0.4",
+    "dlv": "^1.1.2",
     "documentation": "^9.0.0-alpha.1",
     "es6-promisify": "^6.0.1",
     "eslint": "^5.9.0",

--- a/src/dependency-check.js
+++ b/src/dependency-check.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const execa = require('execa')
+
+const runCommand = async (options) => {
+  return execa('dependency-check', ['./package.json', ...options], {
+    stdio: 'inherit'
+  })
+}
+
+module.exports = async (_argv) => { /* eslint-disable no-console */
+  console.log('Checking for missing dependencies of the main library…')
+  await runCommand(['--missing', '--no-dev'])
+
+  console.log('Checking for unused dependencies of the main library…')
+  await runCommand(['--unused', '--no-dev'])
+
+  console.log('Checking for missing dev-dependencies in tests…')
+  await runCommand(['--missing', './test/**/*'])
+
+  console.log('Checking for unused dev-dependencies in tests…')
+  await runCommand(['--unused', './test/**/*'])
+}

--- a/src/dependency-check.js
+++ b/src/dependency-check.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const execa = require('execa')
+const path = require('path')
+const dlv = require('dlv')
 
 const runCommand = async (options) => {
   return execa('dependency-check', ['./package.json', ...options], {
@@ -9,11 +11,15 @@ const runCommand = async (options) => {
 }
 
 module.exports = async (_argv) => { /* eslint-disable no-console */
+  const pkgJSON = require(path.join(process.cwd(), 'package.json'))
+
   console.log('Checking for missing dependencies of the main library…')
-  await runCommand(['--missing', '--no-dev'])
+  await runCommand(['--missing', '--no-dev'].concat(
+    dlv(pkgJSON, 'aegir.dependencyCheck.additionalEntryPoints', [])))
 
   console.log('Checking for unused dependencies of the main library…')
-  await runCommand(['--unused', '--no-dev'])
+  await runCommand(['--unused', '--no-dev'].concat(
+    dlv(pkgJSON, 'aegir.dependencyCheck.additionalEntryPoints', [])))
 
   console.log('Checking for missing dev-dependencies in tests…')
   await runCommand(['--missing', './test/**/*'])


### PR DESCRIPTION
You module might list modules as dependencies that are no longer needed
or can be moved from dependencies to dev-dependencies. With this new
`dependency-check` command you will get a list of those modules.

It doesn't always work correctly, e.g. for AEgir, so manually checking
of the results is needed.

Example:

```console
$ npx aegir dependency-check
Checking for missing dependencies of the main library:
Success! All dependencies used in the code are listed in package.json
Checking for unused dependencies of the main library:
Fail! Modules in package.json not used in code: cids, pull-cat, pull-paramap, pull-traverse
Command failed: dependency-check ./package.json --unused --no-dev
Error: Command failed: dependency-check ./package.json --unused --no-dev
    at makeError (/home/vmx/src/pl/aegir/node_modules/execa/index.js:174:9)
    at Promise.all.then.arr (/home/vmx/src/pl/aegir/node_modules/execa/index.js:278:16)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

On success the output would be like this:

```
Checking for missing dependencies of the main library:
Success! All dependencies used in the code are listed in package.json
Checking for unused dependencies of the main library:
Success! All dependencies in package.json are used in the code
Checking for missing dev-dependencies in tests:
Success! All dependencies used in the code are listed in package.json
Checking for unused dev-dependencies in tests:
Success! All dependencies in package.json are used in the cod
```

Closes #241.