### PR TITLE
fix: pull in karma-entry.js from current directory

### DIFF
--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -38,6 +38,13 @@ const karmaConfig = (config, files, grep, progress) => {
     grep
   }
 
+  const karmaEntry = `${__dirname}/karma-entry.js`
+
+  if (!files.length) {
+    // only try to load *.spec.js if we aren't specifying custom files
+    files.push(karmaEntry)
+  }
+
   return {
     browsers: ['ChromeHeadless'],
     frameworks: isWebworker ? ['mocha-webworker'] : ['mocha'],
@@ -49,10 +56,6 @@ const karmaConfig = (config, files, grep, progress) => {
       }
     }).concat([
       {
-        pattern: 'node_modules/aegir/src/config/karma-entry.js',
-        included: !isWebworker
-      },
-      {
         pattern: 'test/fixtures/**/*',
         watched: false,
         served: true,
@@ -63,16 +66,14 @@ const karmaConfig = (config, files, grep, progress) => {
     preprocessors: files.reduce((acc, f) => {
       acc[f] = ['webpack', 'sourcemap']
       return acc
-    }, {
-      'node_modules/aegir/src/config/karma-entry.js': [ 'webpack', 'sourcemap' ]
-    }),
+    }, {}),
 
     client: {
       mocha,
       mochaWebWorker: {
         pattern: [
           ...files,
-          'node_modules/aegir/src/config/karma-entry.js'
+          'karma-entry.js'
         ],
         mocha
       }


### PR DESCRIPTION
If you are running lerna or another monorepo tool it's common to hoist your dependencies into a parent directory.

The loading of karma tests assumes aegir is in the node_modules directory of your project, which may not be the case if it's been hoisted.

This change loads the `karma-entry.js` file from the current directory instead of the hardcoded node_modules path to ensure that you can actually run your browser tests in a monorepo setup.

It also only adds `karam-entry.js` if we haven't specified custom files to test.