### PR TITLE
feat: take karma browser inactivity timeout from env, if available

### DIFF
--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -115,7 +115,7 @@ const karmaConfig = (config, files, grep, progress) => {
     autoWatch: false,
     singleRun: true,
     colors: true,
-    browserNoActivityTimeout: 50 * 1000
+    browserNoActivityTimeout: process.env.BROWSER_INACTIVITY_TIMEOUT || 50 * 1000
   }
 }
 

--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -115,7 +115,7 @@ const karmaConfig = (config, files, grep, progress) => {
     autoWatch: false,
     singleRun: true,
     colors: true,
-    browserNoActivityTimeout: process.env.BROWSER_INACTIVITY_TIMEOUT || Infinity
+    browserNoActivityTimeout: process.env.BROWSER_INACTIVITY_TIMEOUT || 300 * 1000
   }
 }
 

--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -115,7 +115,7 @@ const karmaConfig = (config, files, grep, progress) => {
     autoWatch: false,
     singleRun: true,
     colors: true,
-    browserNoActivityTimeout: process.env.BROWSER_INACTIVITY_TIMEOUT || 50 * 1000
+    browserNoActivityTimeout: process.env.BROWSER_INACTIVITY_TIMEOUT || Infinity
   }
 }
 


### PR DESCRIPTION
CPU intensive tests in slow browsers can cause this to be reached.