### PR TITLE
chore: fix patch prerelease command snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ $ aegir release --type premajor --preid rc --dist-tag next
 # Minor prerelease (1.0.0 -> 1.1.0-rc.0)
 $ aegir release --type preminor --preid rc --dist-tag next
 # Patch prerelease (1.0.0 -> 1.0.1-rc.0)
-$ aegir release --type preminor --preid rc --dist-tag next
+$ aegir release --type prepatch --preid rc --dist-tag next
 
 # Increment prerelease (1.1.0-rc.0 -> 1.1.0-rc.1)
 $ aegir release --type prerelease --preid rc --dist-tag next


### PR DESCRIPTION
Patch prerelease is using `preminor` instead of `prepatch`