### PR TITLE
Adds no-sandbox to ChromeHeadless

### DIFF
--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -46,7 +46,13 @@ const karmaConfig = (config, files, grep, progress) => {
   }
 
   return {
-    browsers: ['ChromeHeadless'],
+    browsers: ['ChromeHeadlessNoSandbox'],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    },
     frameworks: isWebworker ? ['mocha-webworker'] : ['mocha'],
     basePath: process.cwd(),
     files: files.map(f => {


### PR DESCRIPTION
There are some cases where it doesn't connect to Chrome and you get errors like:

```sh
13 02 2019 11:54:23.451:ERROR [launcher]: ChromeHeadless failed 2 times (timeout). Giving up.

  0 passing (3m)

Command failed: karma start /mnt/c/Users/user/js-libp2p-keychain/node_modules/aegir/src/config/karma.conf.js --files-custom --log-level error
Error: Command failed: karma start /mnt/c/Users/user/js-libp2p-keychain/node_modules/aegir/src/config/karma.conf.js --files-custom --log-level error
    at makeError (/mnt/c/Users/user/js-libp2p-keychain/node_modules/execa/index.js:174:9)
    at Promise.all.then.arr (/mnt/c/Users/user/js-libp2p-keychain/node_modules/execa/index.js:278:16)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:118:7)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! libp2p-keychain@0.3.6 test: `aegir test -t node -t browser`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the libp2p-keychain@0.3.6 test script.
```

I'm running aegir from the Windows Linux Subsystem, and this is the only way to get it working.