### PR TITLE
fix: remove clean documentation theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "browserify-zlib": "~0.2.0",
     "bundlesize": "~0.17.1",
     "chalk": "^2.4.1",
-    "clean-documentation-theme": "~0.5.2",
     "codecov": "^3.1.0",
     "conventional-changelog": "^2.0.3",
     "conventional-github-releaser": "^2.0.0",

--- a/src/docs/build.js
+++ b/src/docs/build.js
@@ -69,7 +69,6 @@ function build (ctx) {
         if (fmt === 'html') {
           return documentation.build(files, getOpts(pkg))
             .then((docs) => documentation.formats.html(docs, {
-              // theme: require.resolve('clean-documentation-theme'),
               version: pkg.version,
               name: pkg.name
             }))

--- a/src/docs/build.js
+++ b/src/docs/build.js
@@ -69,7 +69,7 @@ function build (ctx) {
         if (fmt === 'html') {
           return documentation.build(files, getOpts(pkg))
             .then((docs) => documentation.formats.html(docs, {
-              theme: require.resolve('clean-documentation-theme'),
+              // theme: require.resolve('clean-documentation-theme'),
               version: pkg.version,
               name: pkg.name
             }))


### PR DESCRIPTION
clean-documentation-theme depends on highlight.js which is breaking all `npm i` run this PR removes clean-documentation-theme