### PR TITLE
dep: upgrade karma to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "globby": "^8.0.1",
     "joi": "^14.0.1",
     "json-loader": "~0.5.7",
-    "karma": "^3.1.1",
+    "karma": "^4.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-cli": "^1.0.1",
     "karma-edge-launcher": "~0.4.2",


### PR DESCRIPTION
The tests still pass locally (well, one test wasn’t actually working before the upgrade locally and that one is still failing).

This removes at least one of the annoying deprecation messages we see.