### PR TITLE
feat: require await in functions marked async

### DIFF
--- a/src/checks/commitlint-travis.js
+++ b/src/checks/commitlint-travis.js
@@ -48,7 +48,7 @@ module.exports = async function main () {
   }
 }
 
-async function git (args, options) {
+function git (args, options) {
   return execa(GIT, args, Object.assign({}, { stdio: 'inherit' }, options))
 }
 
@@ -64,7 +64,7 @@ async function isClean () {
   return !(result.stdout && result.stdout.trim())
 }
 
-async function lint (args, options) {
+function lint (args, options) {
   return execa(
     COMMITLINT || commitlint,
     [

--- a/src/config/eslintrc.js
+++ b/src/config/eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
       requireReturn: false,
       requireParamDescription: false,
       requireReturnDescription: false
-    }]
+    }],
+    'require-await': 2
   }
 }


### PR DESCRIPTION
Makes any function marked with the `async` keyword that does not include an `await` fail linting.

This is because the `async` keyword causes the marked function to be wrapped in a promise which creates a vm microtask which introduces a small amount of latency.  In hot codepaths this can add up to large amounts of wasted time.

Closes #354