### PR TITLE
fix: allow development versions to use caret

### DIFF
--- a/src/lint.js
+++ b/src/lint.js
@@ -25,12 +25,21 @@ function checkDependencyVersions () {
       Object.keys(pkg[key]).forEach(name => {
         const version = pkg[key][name]
 
-        if (/^(?!~)([<>=^]{1,2})[0]/.test(version)) {
+        if (/^(?!~)([<>=^]{1,2})0\.0/.test(version)) {
           badVersions.push({
             type,
             name,
             version,
-            message: 'development (e.g. < 1.0.0) versions should start with a ~'
+            message: 'early versions (e.g. < 0.1.0) should start with a ~ or have no range'
+          })
+        }
+
+        if (/^(?![~^])([<>=]{1,2})0/.test(version)) {
+          badVersions.push({
+            type,
+            name,
+            version,
+            message: 'development versions (e.g. < 1.0.0) should start with a ^ or ~'
           })
         }
 

--- a/test/lint.spec.js
+++ b/test/lint.spec.js
@@ -60,6 +60,8 @@ describe('lint', () => {
   it('succeeds when package.json contains dependencies with good versions', function () {
     return dependenciesShouldPassLinting({
       'some-unstable-dep': '~0.0.1',
+      'some-dev-dep': '^0.1.0',
+      'some-other-dev-dep': '~0.1.0',
       'some-stable-dep': '^1.0.0',
       'some-pinned-dep': '1.0.0'
     })
@@ -89,9 +91,33 @@ describe('lint', () => {
     })
   })
 
-  it('fails when package.json contains dependencies with <= for unstable deps', function () {
+  it('fails when package.json contains dependencies with >= for unstable deps', function () {
     return dependenciesShouldFailLinting({
-      'some-dep': '<=0.0.1'
+      'some-dep': '>=0.0.1'
+    })
+  })
+
+  it('fails when package.json contains dependencies with <= for development deps', function () {
+    return dependenciesShouldFailLinting({
+      'some-dep': '<=0.1.0'
+    })
+  })
+
+  it('fails when package.json contains dependencies with > for development deps', function () {
+    return dependenciesShouldFailLinting({
+      'some-dep': '>0.1.0'
+    })
+  })
+
+  it('fails when package.json contains dependencies with < for development deps', function () {
+    return dependenciesShouldFailLinting({
+      'some-dep': '<0.1.0'
+    })
+  })
+
+  it('fails when package.json contains dependencies with >= for development deps', function () {
+    return dependenciesShouldFailLinting({
+      'some-dep': '>=0.1.0'
     })
   })
 


### PR DESCRIPTION
In npm caret (^) and tilde (~) have the same meaning for versions
1.0.0 < x <= 0.1.0. Hence we can allow carat to be used for such
versions.

If you run `npm install <some-packages>` it automatically uses
caret for such versions. Hence you would need to manually update
your package.json to make it pass out linting. With this change
that's no longer needed.

Fixes #346.