### PR TITLE
feat: --100 for full coverage validation

### DIFF
--- a/cmds/test.js
+++ b/cmds/test.js
@@ -15,6 +15,11 @@ module.exports = {
       .example('aegir test -t browser -- --browsers Firefox,Chrome,Safari', 'Tell Karma to run tests in several browsers at the same time.')
       .example('aegir test -w -t browser -- --browser Chrome', 'Debug tests with watch mode and tell Karma to open Chrome in a non-headless mode.')
       .options({
+        '100': {
+          describe: 'Check coverage and validate 100% was covered.',
+          type: 'boolean',
+          default: false
+        },
         target: {
           alias: 't',
           describe: 'In which target environment to execute the tests',

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -62,6 +62,18 @@ function testNode (ctx) {
 
   let err
 
+  if (ctx['100']) {
+    args = [
+      '--check-coverage',
+      '--branches=100',
+      '--functions=100',
+      '--lines=100',
+      '--statements=100',
+      exec
+    ].concat(args)
+    exec = 'nyc'
+  }
+
   return preHook(ctx).then(() => {
     return execa(exec, args.concat(files.map((p) => path.normalize(p))), {
       env: env,


### PR DESCRIPTION
The command for 100% test coverage in nyc is impossibly long. `tap` includes a `—100` option that simplifies this and so I’ve added the same here.

The command currently only applies to node tests until I figure out how to get coverage working in browser tests, but it is possible https://github.com/istanbuljs/puppeteer-to-istanbul