### PR TITLE
feat: support async hooks

### DIFF
--- a/src/config/user.js
+++ b/src/config/user.js
@@ -27,7 +27,10 @@ const HOOK_STAGES = [
 
 function promisifyHooks (hooks) {
   Object.keys(hooks).forEach((key) => {
-    hooks[key] = promisify(hooks[key])
+    if (hooks[key].length) {
+      // hook takes args, is expecting a callback so promisify it
+      hooks[key] = promisify(hooks[key])
+    }
   })
 
   return hooks

--- a/test/config/user.spec.js
+++ b/test/config/user.spec.js
@@ -67,3 +67,60 @@ describe('config - user', () => {
     })
   })
 })
+
+describe('config - user with async hooks', () => {
+  let config
+
+  before(() => {
+    mock('../../src/utils', {
+      getPkg () {
+        return Promise.resolve({
+          name: 'example'
+        })
+      },
+      getUserConfig () {
+        return {
+          webpack: {
+            devtool: 'eval'
+          },
+          entry: 'src/main.js',
+          hooks: {
+            async pre () {
+              await Promise.resolve()
+
+              return 'pre done async'
+            },
+            async post () {
+              await Promise.resolve()
+
+              return 'post done async'
+            }
+          }
+        }
+      },
+      getLibraryName () {
+        return 'Example'
+      },
+      getPathToDist () {
+        return 'dist'
+      },
+      getPathToNodeModules () {
+        return 'aegir/node_modules'
+      },
+      fromRoot () {
+        return './src/index.js'
+      }
+    })
+
+    config = mock.reRequire('../../src/config/user')()
+  })
+
+  after(() => {
+    mock.stop('../../src/utils.js')
+  })
+
+  it('supports async hooks', async () => {
+    expect(await config.hooks.browser.pre()).to.eql('pre done async')
+    expect(await config.hooks.browser.post()).to.eql('post done async')
+  })
+})


### PR DESCRIPTION
A common use of hooks in aegir is to start and stop an ipfs node for browser tests to run against.

Since they all use ipfsd-ctl and that is moving to async/await in ipfs/js-ipfsd-ctl#353 as part of ipfs/js-ipfs#1670, it would be nice to not have to mix async and callbacks in the hooks.

This PR adds support for async hooks while not breaking existing callback based ones.