### PR TITLE
fix: use the default docs theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "babel-plugin-transform-flow-comments": "^6.22.0",
     "browserify-zlib": "~0.2.0",
     "chalk": "^2.4.1",
-    "clean-documentation-theme": "~0.5.2",
     "codecov": "^3.3.0",
     "conventional-changelog": "^3.1.4",
     "conventional-github-releaser": "^3.1.3",

--- a/src/docs/build.js
+++ b/src/docs/build.js
@@ -69,7 +69,6 @@ function build (ctx) {
         if (fmt === 'html') {
           return documentation.build(files, getOpts(pkg))
             .then((docs) => documentation.formats.html(docs, {
-              theme: require.resolve('clean-documentation-theme'),
               version: pkg.version,
               name: pkg.name
             }))

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -7,11 +7,11 @@ const { fromAegir, hook } = require('../utils')
 const DEFAULT_TIMEOUT = global.DEFAULT_TIMEOUT || 5 * 1000
 
 function testNode (ctx) {
-  const exec = 'mocha'
+  let exec = 'mocha'
   const env = { NODE_ENV: 'test' }
   const timeout = ctx.timeout || DEFAULT_TIMEOUT
 
-  const args = [
+  let args = [
     ctx.progress && '--reporter=progress',
     '--ui', 'bdd',
     '--timeout', timeout


### PR DESCRIPTION
Our previous theme was old and unmaintained, because of this  was causing docs generations errors and warnings

closes #369