### PR TITLE
feat: add test-external command

### DIFF
--- a/cmds/test-external.js
+++ b/cmds/test-external.js
@@ -1,0 +1,21 @@
+'use strict'
+
+module.exports = {
+  command: 'test-external <name> <repo>',
+  desc: 'Run the tests of an external module, then upgrade IPFS/http client to the branch version and run them again',
+  builder: {
+    name: {
+      describe: 'The external module\'s name',
+      type: 'string'
+    },
+    repo: {
+      describe: 'The external module\'s repo URL',
+      type: 'string'
+    }
+  },
+  handler (argv) {
+    const cmd = require('../src/test-external')
+    const onError = require('../src/error-handler')
+    cmd(argv).catch(onError)
+  }
+}

--- a/cmds/update-rc.js
+++ b/cmds/update-rc.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  command: 'update-rc [branch]',
+  command: 'update-rc <branch>',
   desc: 'Update a release candidate',
   builder: {
     branch: {

--- a/cmds/update-release-branch-lockfiles.js
+++ b/cmds/update-release-branch-lockfiles.js
@@ -1,0 +1,22 @@
+'use strict'
+
+module.exports = {
+  command: 'update-release-branch-lockfiles <branch>',
+  desc: 'Updates the lockfiles for the release branch',
+  builder: {
+    branch: {
+      describe: 'Which branch to update',
+      type: 'string'
+    },
+    message: {
+      describe: 'The message to use when adding the shrinkwrap and yarn.lock file',
+      type: 'string',
+      default: 'chore: add lockfiles'
+    }
+  },
+  handler (argv) {
+    const cmd = require('../src/update-release-branch-lockfiles')
+    const onError = require('../src/error-handler')
+    cmd(argv).catch(onError)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "gh-pages": "^2.1.1",
     "git-validate": "^2.2.4",
     "globby": "^10.0.1",
+    "it-glob": "~0.0.5",
     "json-loader": "~0.5.7",
     "karma": "^4.3.0",
     "karma-chrome-launcher": "^3.1.0",

--- a/src/publish-rc/index.js
+++ b/src/publish-rc/index.js
@@ -41,7 +41,9 @@ async function publishRc (opts) {
   console.info('Creating release branch', newVersionBranch) // eslint-disable-line no-console
 
   await exec('git', ['checkout', '-b', newVersionBranch])
-  await exec('git', ['push', 'origin', `${newVersionBranch}:${newVersionBranch}`])
+  await exec('git', ['push', 'origin', `${newVersionBranch}:${newVersionBranch}`], {
+    quiet: true
+  })
 
   if (version.includes('-')) {
     // already a pre${opts.type}, change from prepatch, preminor, etc to 'prerelease'
@@ -68,7 +70,9 @@ async function publishRc (opts) {
   })
 
   console.info(`Updating branch ${opts.branch}`) // eslint-disable-line no-console
-  await exec('git', ['push'])
+  await exec('git', ['push'], {
+    quiet: true
+  })
 }
 
 module.exports = publishRc

--- a/src/test-external/index.js
+++ b/src/test-external/index.js
@@ -1,0 +1,170 @@
+'use strict'
+
+const path = require('path')
+const os = require('os')
+const {
+  exec
+} = require('../utils')
+const fs = require('fs-extra')
+const glob = require('it-glob')
+
+const findHttpClientPkg = (targetDir) => {
+  const location = require.resolve('ipfs-http-client', {
+    paths: [
+      targetDir
+    ]
+  })
+
+  return require(location.replace('src/index.js', 'package.json'))
+}
+
+const isDep = (name, pkg) => {
+  return Object.keys(pkg.dependencies || {}).filter(dep => dep === name).pop()
+}
+
+const isDevDep = (name, pkg) => {
+  return Object.keys(pkg.devDependencies || {}).filter(dep => dep === name).pop()
+}
+
+const isOptionalDep = (name, pkg) => {
+  return Object.keys(pkg.optionalDendencies || {}).filter(dep => dep === name).pop()
+}
+
+const dependsOn = (name, pkg) => {
+  return isDep(name, pkg) || isDevDep(name, pkg) || isOptionalDep(name, pkg)
+}
+
+const isMonoRepo = (targetDir) => {
+  return fs.existsSync(path.join(targetDir, 'lerna.json'))
+}
+
+const installDependencies = async (targetDir) => {
+  if (fs.existsSync(path.join(targetDir, 'package-lock.json')) || fs.existsSync(path.join(targetDir, 'npm-shrinkwrap.json'))) {
+    console.info('Installing dependencies using `npm ci`') // eslint-disable-line no-console
+    await exec('npm', ['ci'])
+  } else {
+    console.info('Installing dependencies using `npm install`') // eslint-disable-line no-console
+    await exec('npm', ['install'])
+  }
+}
+
+const linkIPFSInDir = async (targetDir, ipfsDir, ipfsPkg, httpClientPkg) => {
+  process.chdir(targetDir)
+
+  const modulePkgPath = path.join(targetDir, 'package.json')
+  const modulePkg = require(modulePkgPath)
+
+  // if the project also depends on the http client, upgrade it to the same version we are using
+  if (dependsOn('ipfs-http-client', modulePkg)) {
+    console.info('Upgrading ipfs-http-client dependency to', httpClientPkg.version) // eslint-disable-line no-console
+    await exec('npm', ['install', `ipfs-http-client@${httpClientPkg.version}`])
+  }
+
+  console.info(`Linking ipfs@${ipfsPkg.version} in dir ${targetDir}`) // eslint-disable-line no-console
+  await exec('npx', ['connect-deps', 'link', path.relative(await fs.realpath(targetDir), await fs.realpath(ipfsDir))])
+  await exec('npx', ['connect-deps', 'connect'])
+}
+
+const testModule = async (targetDir, ipfsDir, ipfsPkg, httpClientPkg) => {
+  const pkgPath = path.join(targetDir, 'package.json')
+
+  if (!fs.existsSync(pkgPath)) {
+    console.info(`No package.json found at ${pkgPath}`) // eslint-disable-line no-console
+
+    return
+  }
+
+  const modulePkg = require(pkgPath)
+
+  if (!dependsOn('ipfs', modulePkg) && !dependsOn('ipfs-http-client', modulePkg)) {
+    console.info(`Module ${modulePkg.name} does not depend on IPFS or the IPFS HTTP Client`) // eslint-disable-line no-console
+
+    return
+  }
+
+  if (!modulePkg.scripts || !modulePkg.scripts.test) {
+    console.info(`Module ${modulePkg.name} has no tests`) // eslint-disable-line no-console
+
+    return
+  }
+
+  process.chdir(targetDir)
+
+  try {
+    // run the tests without our upgrade - if they are failing, no point in continuing
+    await exec('npm', ['test'])
+  } catch (err) {
+    console.info(err) // eslint-disable-line no-console
+    console.info(`Failed to run the tests of ${modulePkg.name}, aborting`) // eslint-disable-line no-console
+
+    return
+  }
+
+  // upgrade IPFS to the rc
+  await linkIPFSInDir(targetDir, ipfsDir, ipfsPkg, httpClientPkg)
+
+  // run the tests with the new IPFS/IPFSHTTPClient
+  await exec('npm', ['test'])
+}
+
+const testRepo = async (targetDir, ipfsDir, ipfsPkg, httpClientPkg) => {
+  process.chdir(targetDir)
+
+  await installDependencies(targetDir)
+  await testModule(targetDir, ipfsDir, ipfsPkg, httpClientPkg)
+}
+
+const testMonoRepo = async (targetDir, ipfsDir, ipfsPkg, httpClientPkg) => {
+  process.chdir(targetDir)
+
+  await installDependencies(targetDir)
+
+  let lerna = path.join('node_modules', '.bin', 'lerna')
+
+  if (!fs.existsSync(lerna)) {
+    // no lerna in project depenencies :(
+    await exec('npm', ['install', '-g', 'lerna'])
+    lerna = 'lerna'
+  }
+
+  await exec(lerna, ['bootstrap'])
+
+  // read package targetDir config
+  const config = require(path.join(targetDir, 'lerna.json'))
+
+  // find where the packages are stored
+  let packages = config.packages || 'packages'
+
+  if (!Array.isArray(packages)) {
+    packages = [packages]
+  }
+
+  // test each package that depends on ipfs/http client
+  for (const pattern of packages) {
+    for await (const match of glob(targetDir, pattern)) {
+      testModule(path.join(targetDir, match), ipfsDir, ipfsPkg, httpClientPkg)
+    }
+  }
+}
+
+async function testExternal (opts) {
+  // work out our versions
+  const ipfsDir = process.cwd()
+  const ipfsPkg = require(path.join(ipfsDir, 'package.json'))
+  const httpClientPkg = findHttpClientPkg(ipfsDir)
+  const targetDir = path.join(os.tmpdir(), `${opts.name}-${Date.now()}`)
+
+  console.info(`Cloning ${opts.repo} into ${targetDir}`) // eslint-disable-line no-console
+  await exec('git', ['clone', opts.repo, targetDir])
+
+  if (isMonoRepo(targetDir)) {
+    await testMonoRepo(targetDir, ipfsDir, ipfsPkg, httpClientPkg)
+  } else {
+    await testRepo(targetDir, ipfsDir, ipfsPkg, httpClientPkg)
+  }
+
+  console.info(`Removing ${targetDir}`) // eslint-disable-line no-console
+  await fs.remove(targetDir)
+}
+
+module.exports = testExternal

--- a/src/test-external/index.js
+++ b/src/test-external/index.js
@@ -94,8 +94,7 @@ const testModule = async (targetDir, ipfsDir, ipfsPkg, httpClientPkg) => {
     // run the tests without our upgrade - if they are failing, no point in continuing
     await exec('npm', ['test'])
   } catch (err) {
-    console.info(err) // eslint-disable-line no-console
-    console.info(`Failed to run the tests of ${modulePkg.name}, aborting`) // eslint-disable-line no-console
+    console.info(`Failed to run the tests of ${modulePkg.name}, aborting`, err.message) // eslint-disable-line no-console
 
     return
   }
@@ -142,7 +141,7 @@ const testMonoRepo = async (targetDir, ipfsDir, ipfsPkg, httpClientPkg) => {
   // test each package that depends on ipfs/http client
   for (const pattern of packages) {
     for await (const match of glob(targetDir, pattern)) {
-      testModule(path.join(targetDir, match), ipfsDir, ipfsPkg, httpClientPkg)
+      await testModule(path.join(targetDir, match), ipfsDir, ipfsPkg, httpClientPkg)
     }
   }
 }

--- a/src/update-last-successful-build/index.js
+++ b/src/update-last-successful-build/index.js
@@ -60,7 +60,9 @@ async function updateLastSuccessfulBuild (opts) {
 
   try {
     console.info(`Deleting remote ${opts.branch} branch`) // eslint-disable-line no-console
-    await exec('git', ['push', 'origin', `:${opts.branch}`])
+    await exec('git', ['push', 'origin', `:${opts.branch}`], {
+      quiet: true
+    })
   } catch (err) {
     if (!err.message.includes('remote ref does not exist')) {
       throw err
@@ -68,7 +70,9 @@ async function updateLastSuccessfulBuild (opts) {
   }
 
   console.info(`Pushing ${opts.branch} branch`) // eslint-disable-line no-console
-  await exec('git', ['push', 'origin', `${tempBranch}:${opts.branch}`])
+  await exec('git', ['push', 'origin', `${tempBranch}:${opts.branch}`], {
+    quiet: true
+  })
 }
 
 module.exports = updateLastSuccessfulBuild

--- a/src/update-rc/index.js
+++ b/src/update-rc/index.js
@@ -48,7 +48,9 @@ async function updateRc (opts) {
   })
 
   console.info(`Updating branch ${opts.branch}`) // eslint-disable-line no-console
-  await exec('git', ['push'])
+  await exec('git', ['push'], {
+    quiet: true
+  })
 }
 
 module.exports = updateRc

--- a/src/update-rc/index.js
+++ b/src/update-rc/index.js
@@ -6,6 +6,8 @@ const {
 const release = require('../release')
 
 async function updateRc (opts) {
+  await exec('git', ['checkout', 'master'])
+
   try {
     console.info(`Removing local copy of ${opts.branch}`) // eslint-disable-line no-console
     await exec('git', ['branch', '-D', opts.branch])

--- a/src/update-release-branch-lockfiles/index.js
+++ b/src/update-release-branch-lockfiles/index.js
@@ -50,7 +50,9 @@ async function updateReleaseBranchLockfiles (opts) {
   }
 
   console.info(`Pushing ${opts.branch} branch`) // eslint-disable-line no-console
-  await exec('git', ['push', 'origin', `${opts.branch}:${opts.branch}`])
+  await exec('git', ['push', 'origin', `${opts.branch}:${opts.branch}`], {
+    quiet: true
+  })
 }
 
 module.exports = updateReleaseBranchLockfiles

--- a/src/update-release-branch-lockfiles/index.js
+++ b/src/update-release-branch-lockfiles/index.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const {
+  exec
+} = require('../utils')
+
+async function updateReleaseBranchLockfiles (opts) {
+  // when (eventually) run on CI, deps should already be present so need to
+  // remove the lines that remove the node_modules folder
+  await exec('git', ['checkout', 'master'])
+
+  try {
+    console.info(`Removing local copy of ${opts.branch}`) // eslint-disable-line no-console
+    await exec('git', ['branch', '-D', opts.branch])
+  } catch (err) {
+    if (!err.message.includes(`branch '${opts.branch}' not found`)) {
+      throw err
+    }
+  }
+
+  console.info('Fetching repo history') // eslint-disable-line no-console
+  await exec('git', ['fetch'])
+
+  console.info(`Checking out branch ${opts.branch}`) // eslint-disable-line no-console
+  await exec('git', ['checkout', opts.branch])
+
+  console.info('Removing dependencies') // eslint-disable-line no-console
+  await exec('rm', ['-rf', 'node_modules', 'package-lock.json', 'yarn.lock', 'npm-shrinkwrap.json'])
+
+  console.info('Creating yarn.lock') // eslint-disable-line no-console
+  await exec('yarn')
+
+  console.info('Installing dependencies') // eslint-disable-line no-console
+  await exec('npm', ['install'])
+
+  console.info('Creating npm-shrinkwrap.json') // eslint-disable-line no-console
+  await exec('npm', ['shrinkwrap'])
+
+  try {
+    console.info('Committing') // eslint-disable-line no-console
+    await exec('git', ['add', '-f', 'npm-shrinkwrap.json', 'yarn.lock'])
+    await exec('git', ['commit', '-m', opts.message])
+  } catch (err) {
+    if (err.message.includes('nothing to commit, working tree clean')) {
+      console.info('No changes detected, nothing to do') // eslint-disable-line no-console
+      return
+    }
+
+    throw err
+  }
+
+  console.info(`Pushing ${opts.branch} branch`) // eslint-disable-line no-console
+  await exec('git', ['push', 'origin', `${opts.branch}:${opts.branch}`])
+}
+
+module.exports = updateReleaseBranchLockfiles

--- a/src/utils.js
+++ b/src/utils.js
@@ -215,10 +215,13 @@ exports.hook = (env, key) => (ctx) => {
   return Promise.resolve()
 }
 
-exports.exec = (command, args) => {
-  const result = execa(command, args)
+exports.exec = (command, args, options = {}) => {
+  const result = execa(command, args, options)
 
-  result.stdout.pipe(process.stdout)
+  if (!options.quiet) {
+    result.stdout.pipe(process.stdout)
+  }
+
   result.stderr.pipe(process.stderr)
 
   return result


### PR DESCRIPTION
Adds a command to test external/third party repos with a pre-release of js-ipfs.

1. Uses `connect-deps` to `npm link` the js-ipfs repo
2. Clones the target repo to a temp directory
3. Runs the tests of the target repo
4. Upgrades the target repo to use the pre-release of js-ipfs and
  it's supporting `ipfs-http-client` version
5. Runs the tests again with the new version

If the repo doesn't depend on `js-ipfs` or `ipfs-http-client`, prints a warning an exits.

Handles monorepos too, treating each package as a separate target repo.