### PR TITLE
fix: push to the current branch

### DIFF
--- a/src/release/push.js
+++ b/src/release/push.js
@@ -2,12 +2,16 @@
 
 const git = require('simple-git')(process.cwd())
 const pify = require('pify')
+const execa = require('execa')
 
-function push () {
+async function push () {
   const remote = 'origin'
+  const branch = (await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: process.cwd()
+  })).stdout
   return pify(git.push.bind(git))(
     remote,
-    'master',
+    branch,
     {
       // Linter and tests were already run by previous steps
       '--no-verify': true,


### PR DESCRIPTION
During the release process we push tags and the master branch. This only works if we're releasing from the master branch - if we're using a release branch we need to push that instead.

This PR pushes whatever branch we are currently on instead of only pushing master.