### PR TITLE
feat: prefix rc with release

### DIFF
--- a/cmds/publish-rc.js
+++ b/cmds/publish-rc.js
@@ -23,6 +23,11 @@ module.exports = {
       describe: 'What sort of update this will be',
       type: 'string',
       default: 'minor'
+    },
+    prefix: {
+      describe: 'What to prefix the branch name with',
+      type: 'string',
+      default: 'release/'
     }
   },
   handler (argv) {

--- a/src/publish-rc/index.js
+++ b/src/publish-rc/index.js
@@ -35,7 +35,7 @@ async function publishRc (opts) {
   console.info('Found version number', pkg.version) // eslint-disable-line no-console
   const version = pkg.version
   const newVersion = semver.inc(version, opts.type)
-  const newVersionBranch = `v${newVersion.split('.').filter((sub, i) => {
+  const newVersionBranch = `${opts.prefix}v${newVersion.split('.').filter((sub, i) => {
     return i < 2
   }).join('.')}.x`
   console.info('Creating release branch', newVersionBranch) // eslint-disable-line no-console


### PR DESCRIPTION
Default to creating rc branches with names like `release/v0.39.x` instead of just `v0.39.x`

This is so we can use regexes in `.travis.yml` to run certain extra checks on release branches like testing external repos without having to know the release branch name ahead of time.