### PR TITLE
fix: remove manual push after rc publish

### DIFF
--- a/src/publish-rc/index.js
+++ b/src/publish-rc/index.js
@@ -68,11 +68,6 @@ async function publishRc (opts) {
     docs: true,
     ghtoken: opts.ghtoken || process.env.AEGIR_GHTOKEN
   })
-
-  console.info(`Updating branch ${opts.branch}`) // eslint-disable-line no-console
-  await exec('git', ['push'], {
-    quiet: true
-  })
 }
 
 module.exports = publishRc

--- a/src/update-rc/index.js
+++ b/src/update-rc/index.js
@@ -46,11 +46,6 @@ async function updateRc (opts) {
     docs: true,
     ghtoken: opts.ghtoken || process.env.AEGIR_GHTOKEN
   })
-
-  console.info(`Updating branch ${opts.branch}`) // eslint-disable-line no-console
-  await exec('git', ['push'], {
-    quiet: true
-  })
 }
 
 module.exports = updateRc


### PR DESCRIPTION
Since #426 was merged this shouldn't be necessary any more.