### PR TITLE
fix: force --verbose for verbose mode

### DIFF
--- a/cmds/test.js
+++ b/cmds/test.js
@@ -32,7 +32,6 @@ module.exports = {
           default: ['node', 'browser', 'webworker']
         },
         verbose: {
-          alias: 'v',
           describe: 'Print verbose test output',
           type: 'boolean',
           default: false


### PR DESCRIPTION
You can't use `-v` as a command alias as `yargs` thinks you mean `--version`.  You then can't use the long version either (e.g. `--verbose`) as `yargs` *still* thinks you mean `--version`.

```console
$ aegir test -t browser --verbose

20.4.0
```

```console
$ aegir test -t browser -v

20.4.0
```

Removing the `-v` alias makes `--verbose` work as expected.