### PR TITLE
feat: support lockfiles during text-external

### DIFF
--- a/src/test-external/index.js
+++ b/src/test-external/index.js
@@ -38,11 +38,29 @@ const isMonoRepo = (targetDir) => {
   return fs.existsSync(path.join(targetDir, 'lerna.json'))
 }
 
+const hasPackageLock = (targetDir) => {
+  return fs.existsSync(path.join(targetDir, 'package-lock.json'))
+}
+
+const hasYarnLock = (targetDir) => {
+  return fs.existsSync(path.join(targetDir, 'yarn.lock'))
+}
+
 const installDependencies = async (targetDir) => {
   console.info('Installing dependencies') // eslint-disable-line no-console
-  await exec('npm', ['install'], {
-    cwd: targetDir
-  })
+  if (hasYarnLock(targetDir)) {
+    await exec('yarn', ['install'], {
+      cwd: targetDir
+    })
+  } else if (hasPackageLock(targetDir)) {
+    await exec('npm', ['ci'], {
+      cwd: targetDir
+    })
+  } else {
+    await exec('npm', ['install'], {
+      cwd: targetDir
+    })
+  }
 }
 
 const linkIPFSInDir = async (targetDir, ipfsDir, ipfsPkg, httpClientPkg) => {

--- a/src/test-external/index.js
+++ b/src/test-external/index.js
@@ -38,8 +38,9 @@ const isMonoRepo = (targetDir) => {
   return fs.existsSync(path.join(targetDir, 'lerna.json'))
 }
 
-const hasPackageLock = (targetDir) => {
-  return fs.existsSync(path.join(targetDir, 'package-lock.json'))
+const hasNpmLock = (targetDir) => {
+  return fs.existsSync(path.join(targetDir, 'package-lock.json')) ||
+    fs.existsSync(path.join(targetDir, 'npm-shrinkwrap.json'))
 }
 
 const hasYarnLock = (targetDir) => {
@@ -52,7 +53,7 @@ const installDependencies = async (targetDir) => {
     await exec('yarn', ['install'], {
       cwd: targetDir
     })
-  } else if (hasPackageLock(targetDir)) {
+  } else if (hasNpmLock(targetDir)) {
     await exec('npm', ['ci'], {
       cwd: targetDir
     })


### PR DESCRIPTION
> Small improvement on top of #425 

This change detects presence of `yarn.lock` or `package-lock.json` in third-party repo and executes dependency install using optimized command speeding up the build made by `test-external` 

It also stops ipfs-companion from breaking js-ipfs release build if we go overboard with bleeding edge dependency overrides :^)