### PR TITLE
feat: release metadata

### DIFF
--- a/cmds/release.js
+++ b/cmds/release.js
@@ -83,6 +83,11 @@ module.exports = {
       type: 'string',
       default: ''
     },
+    metadata: {
+      describe: 'SemVer metadata to be appended to released version',
+      type: 'string',
+      default: ''
+    },
     type: {
       describe: 'The type of version bump for this release',
       type: 'string',

--- a/src/release/index.js
+++ b/src/release/index.js
@@ -10,6 +10,7 @@ const docs = require('../docs')
 
 const releaseChecks = require('./prerelease')
 const bump = require('./bump')
+const metadata = require('./metadata')
 const changelog = require('./changelog')
 const commit = require('./commit')
 const tag = require('./tag')
@@ -34,6 +35,11 @@ function release (opts) {
       title: 'Bump Version',
       task: bump,
       enabled: (ctx) => ctx.bump
+    },
+    {
+      title: 'Metadata',
+      task: metadata,
+      enabled: (ctx) => ctx.metadata
     },
     {
       title: 'Build',

--- a/src/release/metadata.js
+++ b/src/release/metadata.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const fs = require('fs-extra')
+
+const getPathToPkg = require('../utils').getPathToPkg
+
+function metadata (ctx, task) {
+  const { metadata } = ctx
+
+  return fs.readJson(getPathToPkg())
+    .then((pkg) => {
+      const version = pkg.version
+      const newVersion = `${version}+${metadata}`
+
+      task.title += `: v${version} -> v${newVersion}`
+
+      pkg.version = newVersion
+      return fs.writeJson(getPathToPkg(), pkg, { spaces: 2 })
+    })
+}
+
+module.exports = metadata

--- a/src/release/prerelease.js
+++ b/src/release/prerelease.js
@@ -10,7 +10,7 @@ function validGh (opts) {
 
   if (!opts.ghtoken) {
     return Promise.reject(new Error('Missing GitHub access token. ' +
-                                    'Have you set `AEGIR_GHTOKEN`?'))
+      'Have you set `AEGIR_GHTOKEN`?'))
   }
   return Promise.resolve()
 }
@@ -24,13 +24,23 @@ async function isDirty () {
   }
 }
 
+function isMetadataValid (opts) {
+  if (opts.metadata && !opts.metadata.match(/^[0-9A-Za-z-]+$/)) {
+    return Promise.reject(new Error('The metadata has to consists only of alphanumeric characters and hypen!'))
+  }
+
+  return Promise.resolve()
+}
+
 // Validate that all requirements are met before starting the release
 // - No dirty git
 // - github token for github release, if github release is enabled
+// - Metadata is valid string
 function prerelease (opts) {
   return Promise.all([
     isDirty(),
-    validGh(opts)
+    validGh(opts),
+    isMetadataValid(opts)
   ])
 }
 


### PR DESCRIPTION
SemVer spec allows to the version contain a metadata about the build
using format `<semver>+<metadata>`. This patch extends the release task
with ability to specify metadata to be appended to the version.

This will be used for example in `js-ipfs-repo-migrations` to give information about what latest migration does the release contain as discussed https://github.com/ipfs/js-ipfs-repo-migrations/pull/1#discussion_r336461176