### PR TITLE
fix: specify remote for branch to checkout

### DIFF
--- a/cmds/publish-rc.js
+++ b/cmds/publish-rc.js
@@ -9,6 +9,11 @@ module.exports = {
       type: 'string',
       default: 'build/last-successful'
     },
+    remote: {
+      describe: 'Which remote to use',
+      type: 'string',
+      default: 'origin'
+    },
     distTag: {
       describe: 'The dist tag to publish the rc as',
       type: 'string',

--- a/cmds/update-last-successful-build.js
+++ b/cmds/update-last-successful-build.js
@@ -9,6 +9,11 @@ module.exports = {
       type: 'string',
       default: 'build/last-successful'
     },
+    remote: {
+      describe: 'Which remote to use',
+      type: 'string',
+      default: 'origin'
+    },
     message: {
       describe: 'The message to use when adding the shrinkwrap and yarn.lock file',
       type: 'string',

--- a/cmds/update-rc.js
+++ b/cmds/update-rc.js
@@ -9,6 +9,11 @@ module.exports = {
       describe: 'Where the latest release branch is',
       type: 'string'
     },
+    remote: {
+      describe: 'Which remote to use',
+      type: 'string',
+      default: 'origin'
+    },
     distTag: {
       describe: 'The dist tag to publish the rc as',
       type: 'string',

--- a/cmds/update-release-branch-lockfiles.js
+++ b/cmds/update-release-branch-lockfiles.js
@@ -8,6 +8,11 @@ module.exports = {
       describe: 'Which branch to update',
       type: 'string'
     },
+    remote: {
+      describe: 'Which remote to use',
+      type: 'string',
+      default: 'origin'
+    },
     message: {
       describe: 'The message to use when adding the shrinkwrap and yarn.lock file',
       type: 'string',

--- a/src/publish-rc/index.js
+++ b/src/publish-rc/index.js
@@ -21,7 +21,7 @@ async function publishRc (opts) {
   await exec('git', ['fetch'])
 
   console.info(`Checking out branch ${opts.branch}`) // eslint-disable-line no-console
-  await exec('git', ['checkout', opts.branch])
+  await exec('git', ['checkout', '--track', `origin/${opts.branch}`])
 
   console.info('Removing dependencies') // eslint-disable-line no-console
   await exec('rm', ['-rf', 'node_modules', 'package-lock.json'])

--- a/src/publish-rc/index.js
+++ b/src/publish-rc/index.js
@@ -21,7 +21,7 @@ async function publishRc (opts) {
   await exec('git', ['fetch'])
 
   console.info(`Checking out branch ${opts.branch}`) // eslint-disable-line no-console
-  await exec('git', ['checkout', '--track', `origin/${opts.branch}`])
+  await exec('git', ['checkout', '--track', `${opts.remote}/${opts.branch}`])
 
   console.info('Removing dependencies') // eslint-disable-line no-console
   await exec('rm', ['-rf', 'node_modules', 'package-lock.json'])
@@ -41,7 +41,7 @@ async function publishRc (opts) {
   console.info('Creating release branch', newVersionBranch) // eslint-disable-line no-console
 
   await exec('git', ['checkout', '-b', newVersionBranch])
-  await exec('git', ['push', 'origin', `${newVersionBranch}:${newVersionBranch}`], {
+  await exec('git', ['push', opts.remote, `${newVersionBranch}:${newVersionBranch}`], {
     quiet: true
   })
 
@@ -66,7 +66,8 @@ async function publishRc (opts) {
     publish: true,
     ghrelease: true,
     docs: true,
-    ghtoken: opts.ghtoken || process.env.AEGIR_GHTOKEN
+    ghtoken: opts.ghtoken || process.env.AEGIR_GHTOKEN,
+    remote: opts.remote
   })
 }
 

--- a/src/release/push.js
+++ b/src/release/push.js
@@ -4,8 +4,8 @@ const git = require('simple-git')(process.cwd())
 const pify = require('pify')
 const execa = require('execa')
 
-async function push () {
-  const remote = 'origin'
+async function push (opts) {
+  const remote = opts.remote || 'origin'
   const branch = (await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
     cwd: process.cwd()
   })).stdout

--- a/src/update-last-successful-build/index.js
+++ b/src/update-last-successful-build/index.js
@@ -10,14 +10,14 @@ async function findCurrentBranch () {
   return result.stdout.replace('ref: ', '').trim()
 }
 
-async function findMasterCommit () {
-  const result = await exec('git', ['show-ref', '-s', 'origin/master'])
+async function findMasterCommit (opts) {
+  const result = await exec('git', ['show-ref', '-s', `${opts.remote}/master`])
 
   return result.stdout.trim()
 }
 
-async function isHeadOfMaster () {
-  const master = await findMasterCommit()
+async function isHeadOfMaster (opts) {
+  const master = await findMasterCommit(opts)
   const branch = await findCurrentBranch()
 
   // we either have master checked out or a single commit
@@ -25,7 +25,7 @@ async function isHeadOfMaster () {
 }
 
 async function updateLastSuccessfulBuild (opts) {
-  if (!isHeadOfMaster()) {
+  if (!isHeadOfMaster(opts)) {
     console.info('Will only run on the master branch') // eslint-disable-line no-console
 
     return
@@ -60,7 +60,7 @@ async function updateLastSuccessfulBuild (opts) {
 
   try {
     console.info(`Deleting remote ${opts.branch} branch`) // eslint-disable-line no-console
-    await exec('git', ['push', 'origin', `:${opts.branch}`], {
+    await exec('git', ['push', opts.remote, `:${opts.branch}`], {
       quiet: true
     })
   } catch (err) {
@@ -70,7 +70,7 @@ async function updateLastSuccessfulBuild (opts) {
   }
 
   console.info(`Pushing ${opts.branch} branch`) // eslint-disable-line no-console
-  await exec('git', ['push', 'origin', `${tempBranch}:${opts.branch}`], {
+  await exec('git', ['push', opts.remote, `${tempBranch}:${opts.branch}`], {
     quiet: true
   })
 }

--- a/src/update-rc/index.js
+++ b/src/update-rc/index.js
@@ -44,7 +44,8 @@ async function updateRc (opts) {
     publish: true,
     ghrelease: true,
     docs: true,
-    ghtoken: opts.ghtoken || process.env.AEGIR_GHTOKEN
+    ghtoken: opts.ghtoken || process.env.AEGIR_GHTOKEN,
+    remote: opts.remote
   })
 }
 

--- a/src/update-rc/index.js
+++ b/src/update-rc/index.js
@@ -21,7 +21,7 @@ async function updateRc (opts) {
   await exec('git', ['fetch'])
 
   console.info(`Checking out branch ${opts.branch}`) // eslint-disable-line no-console
-  await exec('git', ['checkout', opts.branch])
+  await exec('git', ['checkout', '--track', `${opts.remote}/${opts.branch}`])
 
   console.info('Removing dependencies') // eslint-disable-line no-console
   await exec('rm', ['-rf', 'node_modules', 'package-lock.json'])

--- a/src/update-release-branch-lockfiles/index.js
+++ b/src/update-release-branch-lockfiles/index.js
@@ -22,7 +22,7 @@ async function updateReleaseBranchLockfiles (opts) {
   await exec('git', ['fetch'])
 
   console.info(`Checking out branch ${opts.branch}`) // eslint-disable-line no-console
-  await exec('git', ['checkout', opts.branch])
+  await exec('git', ['checkout', '--track', `${opts.remote}/${opts.branch}`])
 
   console.info('Removing dependencies') // eslint-disable-line no-console
   await exec('rm', ['-rf', 'node_modules', 'package-lock.json', 'yarn.lock', 'npm-shrinkwrap.json'])

--- a/src/update-release-branch-lockfiles/index.js
+++ b/src/update-release-branch-lockfiles/index.js
@@ -50,7 +50,7 @@ async function updateReleaseBranchLockfiles (opts) {
   }
 
   console.info(`Pushing ${opts.branch} branch`) // eslint-disable-line no-console
-  await exec('git', ['push', 'origin', `${opts.branch}:${opts.branch}`], {
+  await exec('git', ['push', opts.remote, `${opts.branch}:${opts.branch}`], {
     quiet: true
   })
 }


### PR DESCRIPTION
I have many different remotes becuase of checking out branches for external contributors. Git is confused because the branch exists on multiple remotes and fails with:

```
error: pathspec 'build/last-successful' did not match any file(s) known to git
hint: 'build/last-successful' matched more than one remote tracking branch.
```

This fixes that error.