### PR TITLE
fix: no IPFS_JS_EXEC during 1st pass of test-external

### DIFF
--- a/src/test-external/index.js
+++ b/src/test-external/index.js
@@ -111,11 +111,17 @@ const testModule = async (targetDir, ipfsDir, ipfsPkg, httpClientPkg) => {
   try {
     // run the tests without our upgrade - if they are failing, no point in continuing
     await exec('npm', ['test'], {
-      cwd: targetDir
+      cwd: targetDir,
+      env: {
+        // ensure custom js-ipfs is not used for the first run
+        IPFS_JS_EXEC: undefined
+      }
     })
   } catch (err) {
     console.info(`Failed to run the tests of ${modulePkg.name}, aborting`, err.message) // eslint-disable-line no-console
-
+    // We won't be able to test if js-ipfs HEAD caused regression
+    // if upstream tests are broken. We abort and return exit code 0,
+    // as there is no point in breaking the build.
     return
   }
 


### PR DESCRIPTION
> Parent issue: https://github.com/ipfs/js-ipfs/pull/2706/

This fix ensures `IPFS_JS_EXEC` is ignored during the first run of `npm test` in `test-external`.
It will work as expected during the second time `npm test` is run.

### Motivation

We want to run ipfs-webui tests in https://github.com/ipfs/js-ipfs/pull/2706/, 
however, for some reason E2E tests do not use the `ipfs` from `file:*.tgz` defined in `package.json`.

I am not sure what is happening exactly, `connect-deps` does not do the trick, only setting  `IPFS_JS_EXEC` works. Either way, this seems to be a useful fix to merge anyway, as it removes potential side effect from initial pass.

cc @hugomrdias 