### PR TITLE
feat: make unhandled promise rejections fail tests

### DIFF
--- a/cmds/test.js
+++ b/cmds/test.js
@@ -89,6 +89,11 @@ module.exports = {
           describe: 'Use progress reporters on mocha and karma',
           type: 'boolean',
           default: false
+        },
+        noUnhandledPromiseRejections: {
+          describe: 'If true, unhandledRejection events will cause tests to fail',
+          type: 'boolean',
+          default: true
         }
       })
   },

--- a/package.json
+++ b/package.json
@@ -130,7 +130,9 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "cross-env": "^6.0.3",
+    "dirty-chai": "^2.0.1",
     "mock-require": "^3.0.2",
     "sinon": "^7.4.2"
   },

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -17,7 +17,8 @@ function testNode (ctx) {
   let args = [
     ctx.progress && '--reporter=progress',
     '--ui', 'bdd',
-    '--timeout', timeout
+    '--timeout', timeout,
+    `--unhandled-rejections=${ctx.noUnhandledPromiseRejections ? 'strict' : 'warn'}`
   ].filter(Boolean)
 
   let files = [

--- a/test/fixtures/chai.js
+++ b/test/fixtures/chai.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const chai = require('chai')
+
+// Do not reorder these statements - https://github.com/chaijs/chai/issues/1298
+chai.use(require('chai-as-promised'))
+chai.use(require('dirty-chai'))
+
+module.exports.expect = chai.expect

--- a/test/fixtures/tests/unhandled-promise-rejection.js
+++ b/test/fixtures/tests/unhandled-promise-rejection.js
@@ -1,0 +1,12 @@
+/* eslint-env mocha */
+'use strict'
+
+describe('should fail', () => {
+  it('unhandled promise rejection', (done) => {
+    new Promise((resolve, reject) => { // eslint-disable-line no-new
+      reject(new Error('Nope!'))
+    })
+
+    done()
+  })
+})

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -1,7 +1,9 @@
 /* eslint-env mocha */
 'use strict'
 
-const expect = require('chai').expect
+const test = require('../src/test')
+const expect = require('./fixtures/chai').expect
+const path = require('path')
 
 describe('test', () => {
   describe('node', () => {
@@ -32,6 +34,26 @@ describe('test', () => {
       } else {
         expect(false).to.eql(true)
       }
+    })
+  })
+
+  it('unhandled promise rejections should fail tests', async () => {
+    await expect(test.run({
+      target: 'node',
+      files: [
+        path.join(__dirname, 'fixtures', 'tests', 'unhandled-promise-rejection.js')
+      ],
+      noUnhandledPromiseRejections: true
+    })).to.eventually.be.rejected()
+  })
+
+  it('unhandled promise rejections should not fail tests when overridden', async () => {
+    await test.run({
+      target: 'node',
+      files: [
+        path.join(__dirname, 'fixtures', 'tests', 'unhandled-promise-rejection.js')
+      ],
+      noUnhandledPromiseRejections: false
     })
   })
 })


### PR DESCRIPTION
Adds a new flag to the test runner: `--no-unhandled-promise-rejections` which defaults to `true`.

When true this causes the `unhandled-rejections` node flag to be set to `strict` during the test run under node.

This means any `unhandledRejection` events raised on `process` will cause the process to exit and the tests to fail.

This is to ease our transition into the brave new world of mixing error handling strategies between async and event emitters.

Fixes #505