### PR TITLE
fix: remove package-lock before generating npm-shrinkwrap file

### DIFF
--- a/src/update-last-successful-build/index.js
+++ b/src/update-last-successful-build/index.js
@@ -39,11 +39,24 @@ async function updateLastSuccessfulBuild (opts) {
   console.info('Creating temp branch') // eslint-disable-line no-console
   await exec('git', ['checkout', '-b', tempBranch])
 
-  console.info('Creating yarn.lock') // eslint-disable-line no-console
-  await exec('yarn')
+  console.info('Removing dependencies') // eslint-disable-line no-console
+  await exec('rm', ['-rf', 'node_modules', 'package-lock.json', 'yarn.lock', 'npm-shrinkwrap.json'])
+
+  console.info('Installing dependencies') // eslint-disable-line no-console
+  await exec('npm', ['install', '--production'])
+
+  console.info('Removing package-lock.json') // eslint-disable-line no-console
+  await exec('rm', ['-rf', 'package-lock.json']) // removing package-lock after install prevents dev deps being added to the shrinkwrap file
 
   console.info('Creating npm-shrinkwrap.json') // eslint-disable-line no-console
   await exec('npm', ['shrinkwrap'])
+
+  console.info('Creating yarn.lock') // eslint-disable-line no-console
+  await exec('yarn', [], {
+    env: {
+      NODE_ENV: 'production'
+    }
+  })
 
   try {
     console.info('Committing') // eslint-disable-line no-console

--- a/src/update-release-branch-lockfiles/index.js
+++ b/src/update-release-branch-lockfiles/index.js
@@ -27,14 +27,21 @@ async function updateReleaseBranchLockfiles (opts) {
   console.info('Removing dependencies') // eslint-disable-line no-console
   await exec('rm', ['-rf', 'node_modules', 'package-lock.json', 'yarn.lock', 'npm-shrinkwrap.json'])
 
-  console.info('Creating yarn.lock') // eslint-disable-line no-console
-  await exec('yarn')
-
   console.info('Installing dependencies') // eslint-disable-line no-console
-  await exec('npm', ['install'])
+  await exec('npm', ['install', '--production'])
+
+  console.info('Removing package-lock.json') // eslint-disable-line no-console
+  await exec('rm', ['-rf', 'package-lock.json']) // removing package-lock after install prevents dev deps being added to the shrinkwrap file
 
   console.info('Creating npm-shrinkwrap.json') // eslint-disable-line no-console
   await exec('npm', ['shrinkwrap'])
+
+  console.info('Creating yarn.lock') // eslint-disable-line no-console
+  await exec('yarn', [], {
+    env: {
+      NODE_ENV: 'production'
+    }
+  })
 
   try {
     console.info('Committing') // eslint-disable-line no-console


### PR DESCRIPTION
`npm shrinkwrap` renames your `package-lock.json` if present, this includes project dev deps which npm [seems to be installing](https://github.com/ipfs/js-ipfs/issues/2774) even though the published module with the shrinkwrap file is a dependency.

If we install with the `--production` flag, then remove the `package-lock.json` file and *then* run shrinkwrap, no dev deps are included in the shrinkwrap file.

This only affects npm, yarn seems to do the right thing.

Fixes #516