### PR TITLE
fix: pass --full-trace option to electron-mocha

### DIFF
--- a/src/test/electron.js
+++ b/src/test/electron.js
@@ -27,6 +27,7 @@ module.exports = (argv) => {
         ...bail,
         ...timeout,
         ['--colors'],
+        ['--full-trace'],
         ...renderer,
         ...forwardOptions
       ], {


### PR DESCRIPTION
To get stack traces out of electron-mocha we need to pass this flag.

See: https://github.com/jprichardson/electron-mocha/blob/master/lib/run.js#L166