### PR TITLE
fix: fix webpack warn, make electron lazy

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@commitlint/load": "^8.3.5",
     "@commitlint/read": "^8.3.4",
     "@commitlint/travis-cli": "^8.3.5",
+    "@electron/get": "^1.9.0",
     "babel-loader": "^8.0.5",
     "babel-plugin-transform-flow-comments": "^6.22.0",
     "bundlesize": "~0.18.0",
@@ -63,7 +64,6 @@
     "conventional-github-releaser": "^3.1.3",
     "dependency-check": "^4.1.0",
     "documentation": "^12.1.4",
-    "electron": "^8.0.0",
     "electron-mocha": "^8.2.0",
     "eslint": "^6.3.0",
     "eslint-config-standard": "^14.1.0",
@@ -73,6 +73,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "execa": "^4.0.0",
+    "extract-zip": "^1.6.7",
     "findup-sync": "^4.0.0",
     "fs-extra": "^8.1.0",
     "gh-pages": "^2.2.0",
@@ -98,7 +99,8 @@
     "mocha": "^7.0.1",
     "npm-package-json-lint": "^4.5.1",
     "nyc": "^15.0.0",
-    "p-map": "^3.0.0",
+    "ora": "^4.0.3",
+    "p-map": "^4.0.0",
     "pascalcase": "^1.0.0",
     "pify": "^5.0.0",
     "prompt-promise": "^1.0.3",
@@ -117,15 +119,16 @@
     "webpack-cli": "^3.3.10",
     "webpack-merge": "^4.2.2",
     "yargs": "^15.1.0",
-    "yargs-parser": "^17.0.0"
+    "yargs-parser": "^18.1.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.0",
     "dirty-chai": "^2.0.1",
+    "electron": "^8.0.0",
     "mock-require": "^3.0.2",
-    "sinon": "^9.0.0"
+    "sinon": "^9.0.1"
   },
   "engines": {
     "node": ">=10.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   ],
   "main": "cli.js",
   "browser": {
-    "fs": false
+    "fs": false,
+    "./src/fixtures.js": "./src/fixtures.browser.js"
   },
   "bin": {
     "aegir": "cli.js"

--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -72,6 +72,10 @@ const karmaConfig = (config, argv) => {
       }
     ]),
 
+    proxies: {
+      '/test/fixtures/': '/base/test/fixtures/'
+    },
+
     preprocessors: files.reduce((acc, f) => {
       acc[f] = ['webpack', 'sourcemap']
       return acc

--- a/src/fixtures.browser.js
+++ b/src/fixtures.browser.js
@@ -1,0 +1,31 @@
+/* global self */
+'use strict'
+
+// note: filePath needs to be relative to the module root
+module.exports = function loadFixtures (filePath, module) {
+  return syncXhr(filePath)
+}
+
+// @dignifiedquire: I know this is considered bad practice (syncXhr), but it
+// makes testing life so much nicer!
+function syncXhr (filePath) {
+  const target = filePath
+
+  const request = new self.XMLHttpRequest()
+  request.open('GET', target, false)
+  request.overrideMimeType('text/plain; charset=x-user-defined')
+  request.send(null)
+
+  if (request.status === 200) {
+    const filestream = request.responseText
+    const res = new Uint8Array(filestream.length)
+
+    for (let i = 0; i < filestream.length; i++) {
+      res[i] = filestream.charCodeAt(i) & 0xff
+    }
+
+    return Buffer.from(res)
+  } else {
+    throw new Error(`Could not get the Fixture: ${filePath}`)
+  }
+}

--- a/src/fixtures.js
+++ b/src/fixtures.js
@@ -1,61 +1,27 @@
-/* global self */
 'use strict'
 
-const { isNode, isElectron } = require('ipfs-utils/src/env')
 const path = require('path')
 
 // note: filePath needs to be relative to the module root
 module.exports = function loadFixtures (filePath, module) {
-  if (isNode || isElectron) {
-    if (module) {
-      filePath = path.join(module, filePath)
-    }
-
-    const fs = require('fs')
-    const paths = [
-      path.join(process.cwd(), filePath),
-      path.join(process.cwd(), 'node_modules', filePath),
-      resolve(filePath)
-    ]
-
-    const resourcePath = paths.find(path => fs.existsSync(path))
-
-    if (!resourcePath) {
-      throw new Error(`Could not load ${filePath}`)
-    }
-
-    return fs.readFileSync(resourcePath)
-  } else {
-    if (module) {
-      filePath = path.join('node_modules', module, filePath)
-    }
-
-    return syncXhr(filePath)
+  if (module) {
+    filePath = path.join(module, filePath)
   }
-}
 
-// @dignifiedquire: I know this is considered bad practice (syncXhr), but it
-// makes testing life so much nicer!
-function syncXhr (filePath) {
-  const target = path.join('/base', filePath)
+  const fs = require('fs')
+  const paths = [
+    path.join(process.cwd(), filePath),
+    path.join(process.cwd(), 'node_modules', filePath),
+    resolve(filePath)
+  ]
 
-  const request = new self.XMLHttpRequest()
-  request.open('GET', target, false)
-  request.overrideMimeType('text/plain; charset=x-user-defined')
-  request.send(null)
+  const resourcePath = paths.find(path => fs.existsSync(path))
 
-  if (request.status === 200) {
-    const filestream = request.responseText
-    const res = new Uint8Array(filestream.length)
-
-    for (let i = 0; i < filestream.length; i++) {
-      res[i] = filestream.charCodeAt(i) & 0xff
-    }
-
-    return Buffer.from(res)
-  } else {
-    throw new Error(`Could not get the Fixture: ${filePath}`)
+  if (!resourcePath) {
+    throw new Error(`Could not load ${filePath}`)
   }
+
+  return fs.readFileSync(resourcePath)
 }
 
 function resolve (filePath) {

--- a/src/test/electron.js
+++ b/src/test/electron.js
@@ -1,7 +1,7 @@
 'use strict'
 const path = require('path')
 const execa = require('execa')
-const { hook } = require('../utils')
+const { hook, getElectron } = require('../utils')
 
 module.exports = (argv) => {
   const input = argv._.slice(1)
@@ -16,7 +16,8 @@ module.exports = (argv) => {
   const renderer = argv.renderer ? ['--renderer'] : []
 
   return hook('browser', 'pre')(argv.userConfig)
-    .then(() => {
+    .then(() => getElectron())
+    .then((electronPath) => {
       return execa('electron-mocha', [
         ...input,
         ...files,
@@ -35,7 +36,9 @@ module.exports = (argv) => {
         preferLocal: true,
         stdio: 'inherit',
         env: {
-          AEGIR_RUNNER: argv.renderer ? 'electron-renderer' : 'electron-main'
+          NODE_ENV: process.env.NODE_ENV || 'test',
+          AEGIR_RUNNER: argv.renderer ? 'electron-renderer' : 'electron-main',
+          ELECTRON_PATH: electronPath
         }
       })
     })

--- a/src/utils.js
+++ b/src/utils.js
@@ -263,11 +263,12 @@ function extractFile (zipPath) {
 }
 
 exports.getElectron = async () => {
+  const pkg = require('./../package.json')
   const version = pkg.devDependencies.electron.slice(1)
-  const spinner = ora(`Downloading electron: ${version}.`).start()
+  const spinner = ora(`Downloading electron: ${version}`).start()
   const zip = await download(version)
-  spinner.text = 'Extracting electron to system cache.'
+  spinner.text = 'Extracting electron to system cache'
   const electronPath = await extractFile(zip)
-  spinner.succeed('Electron ready to use.')
+  spinner.succeed('Electron ready to use')
   return electronPath
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,10 @@
  */
 'use strict'
 
+const os = require('os')
+const ora = require('ora')
+const extract = require('extract-zip')
+const { download } = require('@electron/get')
 const path = require('path')
 const findUp = require('findup-sync')
 const readPkgUp = require('read-pkg-up')
@@ -224,4 +228,46 @@ exports.exec = (command, args, options = {}) => {
   result.stderr.pipe(process.stderr)
 
   return result
+}
+
+function getPlatformPath () {
+  const platform = process.env.npm_config_platform || os.platform()
+
+  switch (platform) {
+    case 'mas':
+    case 'darwin':
+      return 'Electron.app/Contents/MacOS/Electron'
+    case 'freebsd':
+    case 'openbsd':
+    case 'linux':
+      return 'electron'
+    case 'win32':
+      return 'electron.exe'
+    default:
+      throw new Error('Electron builds are not available on platform: ' + platform)
+  }
+}
+
+function extractFile (zipPath) {
+  const electronPath = path.join(path.dirname(zipPath), getPlatformPath())
+  if (fs.existsSync(electronPath)) {
+    return Promise.resolve(electronPath)
+  }
+  return new Promise((resolve, reject) => {
+    extract(zipPath, { dir: path.dirname(zipPath) }, err => {
+      if (err) return reject(err)
+
+      resolve(electronPath)
+    })
+  })
+}
+
+exports.getElectron = async () => {
+  const version = pkg.devDependencies.electron.slice(1)
+  const spinner = ora(`Downloading electron: ${version}.`).start()
+  const zip = await download(version)
+  spinner.text = 'Extracting electron to system cache.'
+  const electronPath = await extractFile(zip)
+  spinner.succeed('Electron ready to use.')
+  return electronPath
 }

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -6,12 +6,12 @@ const expect = require('chai').expect
 
 describe('browser', () => {
   it('fixtures', () => {
-    const myFixture = loadFixture('test/fixtures/test.txt')
+    const myFixture = loadFixture('/test/fixtures/test.txt')
     expect(myFixture.toString()).to.be.eql('Hello Fixture\n')
   })
 
   it('non existing fixtures', () => {
-    expect(() => loadFixture('test/fixtures/asdalkdjaskldjatest.txt'))
+    expect(() => loadFixture('/test/fixtures/asdalkdjaskldjatest.txt'))
       .to.throw()
   })
 })


### PR DESCRIPTION
This makes the served assets simpler and splits fixtures loading into node/browser files.
These changes make aegir works with karma and future browser runner `playwright-test`


lets try to stop electron from eager download the binaries 

prev:     Total disk usage: 302.3 MiB  Apparent size: 237.2 MiB  Items: 25368
now:      Total disk usage: 137.6 MiB  Apparent size:  75.4 MiB  Items: 25007
no-karma: Total disk usage: 135.0 MiB  Apparent size:  74.0 MiB  Items: 24441

- [x] remove electron from deps (into dev deps) and lazy download binaries
- [x] remove karma packages
- [ ] rewrite browser tests with playwright-test