### PR TITLE
feat: allow enabling/disabling each part of the release process

### DIFF
--- a/cmds/release.js
+++ b/cmds/release.js
@@ -53,8 +53,23 @@ module.exports = {
       type: 'boolean',
       default: true
     },
+    commit: {
+      describe: 'Commit changes to git',
+      type: 'boolean',
+      default: true
+    },
+    tag: {
+      describe: 'Create release tag in git',
+      type: 'boolean',
+      default: true
+    },
+    push: {
+      describe: 'Push changes to GitHub',
+      type: 'boolean',
+      default: true
+    },
     ghrelease: {
-      describe: 'Genereate GitHub release',
+      describe: 'Generate GitHub release',
       type: 'boolean',
       default: true
     },

--- a/src/release/contributors.js
+++ b/src/release/contributors.js
@@ -1,18 +1,25 @@
 'use strict'
 
+const git = require('simple-git')(process.cwd())
+const pify = require('pify')
 const execa = require('execa')
 const { getPathToPkg } = require('../utils')
 
 const contributors = async () => {
   await execa('git-authors-cli', ['--print', 'false'])
-  await execa('git', [
-    'commit',
-    getPathToPkg(),
-    '-m',
+
+  const res = await pify(git.status.bind(git))()
+
+  if (!res.modified.length) {
+    return
+  }
+
+  await pify(git.commit.bind(git))(
     'chore: update contributors',
-    '--no-verify',
-    '--allow-empty'
-  ])
+    getPathToPkg(), {
+      '--no-verify': true
+    }
+  )
 }
 
 module.exports = contributors

--- a/src/release/index.js
+++ b/src/release/index.js
@@ -12,15 +12,13 @@ const releaseChecks = require('./prerelease')
 const bump = require('./bump')
 const changelog = require('./changelog')
 const commit = require('./commit')
+const tag = require('./tag')
 const contributors = require('./contributors')
 const github = require('./github')
 const publish = require('./publish')
 const push = require('./push')
 
 function release (opts) {
-  // enable publishing for docs
-  opts.publish = true
-
   const tasks = new Listr([{
     title: 'Lint',
     task: lint,
@@ -47,10 +45,16 @@ function release (opts) {
     enabled: (ctx) => ctx.changelog
   }, {
     title: 'Commit to Git',
-    task: commit
+    task: commit,
+    enabled: (ctx) => ctx.commit
+  }, {
+    title: 'Tag release',
+    task: tag,
+    enabled: (ctx) => ctx.tag
   }, {
     title: 'Push to GitHub',
-    task: push
+    task: push,
+    enabled: (ctx) => ctx.push
   }, {
     title: 'Generate GitHub Release',
     task: github,

--- a/src/release/tag.js
+++ b/src/release/tag.js
@@ -6,19 +6,12 @@ const fs = require('fs-extra')
 
 const getPathToPkg = require('../utils').getPathToPkg
 
-const files = ['package.json', 'CHANGELOG.md']
-
-async function commit () {
-  await pify(git.add.bind(git))(files)
-
+async function tag () {
   const {
     version
   } = await fs.readJson(getPathToPkg())
 
-  await pify(git.commit.bind(git))(
-    `chore: release version v${version}`,
-    files
-  )
+  await pify(git.addTag.bind(git))(`v${version}`)
 }
 
-module.exports = commit
+module.exports = tag


### PR DESCRIPTION
Also splits commit/tagging into two separate commands and checks for file modifications before committing updated contributor lists.