### PR TITLE
feat: turn off sourcemaps for production builds

### DIFF
--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -19,7 +19,6 @@ const env = {
 
 // Webpack overrides for karma
 const karmaWebpackConfig = merge.strategy({ plugins: 'replace' })(webpackConfig(), {
-  devtool: 'source-map',
   entry: '',
   output: {
     libraryTarget: 'var'

--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -19,6 +19,7 @@ const env = {
 
 // Webpack overrides for karma
 const karmaWebpackConfig = merge.strategy({ plugins: 'replace' })(webpackConfig(), {
+  devtool: 'source-map',
   entry: '',
   output: {
     libraryTarget: 'var'

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -22,7 +22,6 @@ const base = (env, argv) => {
   return {
     bail: Boolean(isProduction),
     mode: isProduction ? 'production' : 'development',
-    devtool: isProduction ? undefined : 'source-map',
     entry: [userConfig.entry],
     output: {
       path: fromRoot(paths.dist),
@@ -176,39 +175,9 @@ module.exports = (env, argv) => {
       external
     )
   }
-  if (isProduction) {
-    return [
-      merge(
-        base(env, argv),
-        {
-          output: {
-            filename: 'index.js',
-            sourceMapFilename: 'index.js.map'
-          },
-          optimization: {
-            minimize: false
-          }
-        },
-        external
-      ),
-      merge(
-        base(env, argv),
-        external
-      )
-    ]
-  }
 
   return merge(
     base(env, argv),
-    {
-      output: {
-        filename: 'index.js',
-        sourceMapFilename: 'index.js.map'
-      },
-      optimization: {
-        minimize: false
-      }
-    },
     external
   )
 }

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -22,7 +22,7 @@ const base = (env, argv) => {
   return {
     bail: Boolean(isProduction),
     mode: isProduction ? 'production' : 'development',
-    devtool: isProduction ? 'source-map' : undefined,
+    devtool: isProduction ? undefined : 'source-map',
     entry: [userConfig.entry],
     output: {
       path: fromRoot(paths.dist),


### PR DESCRIPTION
They aren't massively useful as unless you are on the laptop of the person who published the build, all the paths are wrong.

Fixes #483, https://github.com/ipfs/js-ipfs/issues/3006