### PR TITLE
feat: send body back in echo response if sent

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,9 @@
     "globby": "^11.0.0",
     "ipfs-utils": "^2.2.0",
     "it-glob": "~0.0.8",
+    "it-to-buffer": "^1.0.2",
     "json-loader": "~0.5.7",
+    "json-stringify-safe": "^5.0.1",
     "karma": "^5.0.3",
     "karma-chrome-launcher": "^3.1.0",
     "karma-cli": "^2.0.0",
@@ -133,6 +135,7 @@
     "electron": "^8.2.4",
     "iso-url": "^0.4.7",
     "mock-require": "^3.0.2",
+    "node-fetch": "^2.6.0",
     "sinon": "^9.0.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "webpack-bundle-analyzer": "^3.7.0",
     "webpack-cli": "^3.3.10",
     "webpack-merge": "^4.2.2",
-    "yargs": "^15.1.0",
+    "yargs": "^15.3.1",
     "yargs-parser": "^18.1.3"
   },
   "devDependencies": {

--- a/test/echo-server.js
+++ b/test/echo-server.js
@@ -1,0 +1,67 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('../utils/chai')
+const { format } = require('iso-url')
+const fetch = require('node-fetch')
+const EchoServer = require('../utils/echo-server')
+
+describe('echo-server', function () {
+  let echo
+  let echoServerUrl
+
+  beforeEach(async () => {
+    echo = new EchoServer()
+
+    const server = await echo.start()
+    const { address, port } = server.server.address()
+
+    echoServerUrl = format({ protocol: 'http:', hostname: address, port })
+  })
+
+  afterEach(async () => {
+    await echo.stop()
+  })
+
+  it('should echo request', async () => {
+    const req = await fetch(`${echoServerUrl}/echo?foo=bar`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json+sent-by-test'
+      },
+      body: JSON.stringify({
+        foo: 'bar'
+      })
+    })
+
+    const rsp = JSON.parse(await req.text())
+    expect(rsp).to.have.nested.property('headers.content-type', 'application/json+sent-by-test')
+    expect(rsp).to.have.nested.property('body.foo', 'bar')
+    expect(rsp).to.have.nested.property('query.foo', 'bar')
+  })
+
+  it('should redirect request', async () => {
+    const req = await fetch(`${echoServerUrl}/redirect?to=bar`, {
+      redirect: 'manual'
+    })
+
+    expect(req).to.have.property('status', 302)
+    expect(req.headers.get('location')).to.equal(`${echoServerUrl}/bar`)
+  })
+
+  it('should redirect request to external url', async () => {
+    const req = await fetch(`${echoServerUrl}/redirect?to=http://example.com/blah`, {
+      redirect: 'manual'
+    })
+
+    expect(req).to.have.property('status', 302)
+    expect(req.headers.get('location')).to.equal('http://example.com/blah')
+  })
+
+  it('should download data', async () => {
+    const req = await fetch(`${echoServerUrl}/download?data=hello`)
+
+    const rsp = await req.text()
+    expect(rsp).to.equal('hello')
+  })
+})

--- a/test/node.js
+++ b/test/node.js
@@ -1,5 +1,6 @@
 'use strict'
 
+require('./echo-server')
 require('./utils')
 require('./test')
 require('./lint')


### PR DESCRIPTION
If you send a body, echo it back as the `body` property of the response.

Uses `json-stringify-safe` to serialize the request otherwise it doesn't work because it contains circular references.

Also adds tests for some of the echo server routes as they weren't tested.

Not sure why we need the `/echo/query` route, the basic `/echo` route can be used instead.