### PR TITLE
fix: whitelist process env keys

### DIFF
--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -10,6 +10,7 @@ const isWebworker = process.env.AEGIR_RUNNER === 'webworker'
 
 // Env to pass in the bundle with DefinePlugin
 const env = {
+  'process.env': JSON.stringify(process.env),
   TEST_DIR: JSON.stringify(fromRoot('test')),
   TEST_BROWSER_JS: hasFile('test', 'browser.js')
     ? JSON.stringify(fromRoot('test', 'browser.js'))

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -108,7 +108,10 @@ const base = (env, argv) => {
       ]
     },
     plugins: [
-      new webpack.DefinePlugin({ 'process.env': JSON.stringify(process.env) })
+      new webpack.DefinePlugin({ 'process.env': JSON.stringify({
+        DEBUG: process.env.DEBUG,
+        NODE_ENV: process.env.NODE_ENV
+      }) })
     ],
     target: 'web',
     node: process.env.AEGIR_NODE === 'false' ? {

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -108,10 +108,12 @@ const base = (env, argv) => {
       ]
     },
     plugins: [
-      new webpack.DefinePlugin({ 'process.env': JSON.stringify({
-        DEBUG: process.env.DEBUG,
-        NODE_ENV: process.env.NODE_ENV
-      }) })
+      new webpack.DefinePlugin({
+        'process.env': JSON.stringify({
+          DEBUG: process.env.DEBUG,
+          NODE_ENV: process.env.NODE_ENV
+        })
+      })
     ],
     target: 'web',
     node: process.env.AEGIR_NODE === 'false' ? {


### PR DESCRIPTION
Do not put the users' whole env into the bundle, instead, just add the keys we want.

I don't know if we need other keys, but we definitely should not be including everything.