### PR TITLE
feat: default to not include node globals anf builtins

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,6 +34,12 @@ cli
     default: false,
     alias: 'debug'
   })
+  // TODO remove after webpack 5 upgrade
+  .options('node', {
+    type: 'boolean',
+    describe: 'Flag to control if bundler should inject node globals or built-ins.',
+    default: false
+  })
   .help()
   .alias('h', 'help')
   .alias('v', 'version')

--- a/cmds/build.js
+++ b/cmds/build.js
@@ -10,11 +10,6 @@ module.exports = {
     yargs
       .epilog(EPILOG)
       .options({
-        node: {
-          type: 'boolean',
-          describe: 'Flag to control when to tell the bundler to include node global packages.',
-          default: true
-        },
         bundlesize: {
           alias: 'b',
           type: 'boolean',

--- a/cmds/test.js
+++ b/cmds/test.js
@@ -94,11 +94,6 @@ module.exports = {
           describe: 'If true, unhandledRejection events will cause tests to fail',
           type: 'boolean',
           default: true
-        },
-        node: {
-          type: 'boolean',
-          describe: 'Flag to control when to tell the bundler to include node global packages.',
-          default: true
         }
       })
   },

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -124,7 +124,9 @@ const base = (env, argv) => {
       tls: false,
       child_process: false,
       console: false,
-      process: true, // TODO remove this once readable-stream is fixed
+      // TODO remove this once readable-stream is fixed probably on in v4
+      // https://github.com/nodejs/readable-stream/pull/435
+      process: true,
       Buffer: false,
       setImmediate: false,
       os: false,


### PR DESCRIPTION
This PR changes webpack config to not include node globals and built-ins by default.

Tracking issue here https://github.com/ipfs/js-ipfs/issues/2924

For now theres still a --node flag to allow node globals if needed.

`process` is still included because `readable-stream` will only remove it in v4 https://github.com/nodejs/readable-stream/pull/435

BREAKING CHANGE: browser code will NOT have node globals and builtins available.