### PR TITLE
fix: update bundlesize help command

### DIFF
--- a/cmds/build.js
+++ b/cmds/build.js
@@ -13,7 +13,7 @@ module.exports = {
         bundlesize: {
           alias: 'b',
           type: 'boolean',
-          describe: 'Analyse bundle size. Default threshold is 100kB, you can override that in `.aegir.js` with the property `bundlesize`.',
+          describe: 'Analyse bundle size. Default threshold is 100kB, you can override that in `.aegir.js` with the property `bundlesize.maxSize`.',
           default: false
         }
       })


### PR DESCRIPTION
The config for limiting the bundlesize is:

```js
{
  bundlesize: {
    maxSize: '100kB'
  }
}
```

and not

```js
{
  bundlesize: '100kB'
}
```

as the help text implies.