### PR TITLE
feat: Use file type based lint rules

### DIFF
--- a/src/config/eslintrc-js.js
+++ b/src/config/eslintrc-js.js
@@ -1,0 +1,51 @@
+'use strict'
+
+module.exports = {
+  extends: 'standard',
+  parserOptions: {
+    sourceType: 'script'
+  },
+  globals: {
+    self: true,
+    mocha: true
+  },
+  plugins: [
+    'no-only-tests'
+  ],
+  rules: {
+    strict: [2, 'safe'],
+    curly: 'error',
+    'block-scoped-var': 2,
+    complexity: 1,
+    'default-case': 2,
+    'dot-notation': 1,
+    'guard-for-in': 1,
+    'linebreak-style': [1, 'unix'],
+    'no-alert': 2,
+    'no-case-declarations': 2,
+    'no-console': 2,
+    'no-constant-condition': 2,
+    'no-continue': 1,
+    'no-div-regex': 2,
+    'no-empty': 1,
+    'no-empty-pattern': 2,
+    'no-extra-semi': 2,
+    'no-implicit-coercion': 2,
+    'no-labels': 2,
+    'no-loop-func': 2,
+    'no-nested-ternary': 1,
+    'no-only-tests/no-only-tests': 2,
+    'no-script-url': 2,
+    'no-warning-comments': 1,
+    'quote-props': [2, 'as-needed'],
+    'require-yield': 2,
+    'max-nested-callbacks': [2, 4],
+    'max-depth': [2, 4],
+    'valid-jsdoc': [2, {
+      requireReturn: false,
+      requireParamDescription: false,
+      requireReturnDescription: false
+    }],
+    'require-await': 2
+  }
+}

--- a/src/config/eslintrc-ts.js
+++ b/src/config/eslintrc-ts.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   plugins: ['@typescript-eslint'],
   extends: [
-    fromAegir('src/config/eslintrc.js'),
+    fromAegir('src/config/eslintrc-js.js'),
     'plugin:@typescript-eslint/recommended'
   ]
 }

--- a/src/config/eslintrc.js
+++ b/src/config/eslintrc.js
@@ -1,51 +1,18 @@
 'use strict'
-
+const { fromAegir } = require('../utils')
 module.exports = {
-  extends: 'standard',
-  parserOptions: {
-    sourceType: 'script'
-  },
-  globals: {
-    self: true,
-    mocha: true
-  },
-  plugins: [
-    'no-only-tests'
-  ],
-  rules: {
-    strict: [2, 'safe'],
-    curly: 'error',
-    'block-scoped-var': 2,
-    complexity: 1,
-    'default-case': 2,
-    'dot-notation': 1,
-    'guard-for-in': 1,
-    'linebreak-style': [1, 'unix'],
-    'no-alert': 2,
-    'no-case-declarations': 2,
-    'no-console': 2,
-    'no-constant-condition': 2,
-    'no-continue': 1,
-    'no-div-regex': 2,
-    'no-empty': 1,
-    'no-empty-pattern': 2,
-    'no-extra-semi': 2,
-    'no-implicit-coercion': 2,
-    'no-labels': 2,
-    'no-loop-func': 2,
-    'no-nested-ternary': 1,
-    'no-only-tests/no-only-tests': 2,
-    'no-script-url': 2,
-    'no-warning-comments': 1,
-    'quote-props': [2, 'as-needed'],
-    'require-yield': 2,
-    'max-nested-callbacks': [2, 4],
-    'max-depth': [2, 4],
-    'valid-jsdoc': [2, {
-      requireReturn: false,
-      requireParamDescription: false,
-      requireReturnDescription: false
-    }],
-    'require-await': 2
-  }
+  overrides: [
+    {
+      files: [
+        '**/*.js'
+      ],
+      extends: fromAegir('src/config/eslintrc-js.js')
+    },
+    {
+      files: [
+        '**/*.ts'
+      ],
+      extends: fromAegir('src/config/eslintrc-ts.js')
+    }
+  ]
 }

--- a/src/lint.js
+++ b/src/lint.js
@@ -83,7 +83,7 @@ function checkDependencyVersions () {
 function runLinter (opts = {}) {
   const cli = new CLIEngine({
     useEslintrc: true,
-    baseConfig: opts.ts ? require('./config/eslintrc-ts.js') : require('./config/eslintrc.js'),
+    baseConfig: require('./config/eslintrc.js'),
     fix: opts.fix
   })
 

--- a/test/fixtures/js+ts/package.json
+++ b/test/fixtures/js+ts/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "my-project"
+}

--- a/test/fixtures/js+ts/src/another.ts
+++ b/test/fixtures/js+ts/src/another.ts
@@ -1,0 +1,5 @@
+import { hello } from './typed'
+
+export const main = ():void => {
+  hello('world')
+}

--- a/test/fixtures/js+ts/src/some.js
+++ b/test/fixtures/js+ts/src/some.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const main = () => {
+
+}
+
+module.exports = main

--- a/test/fixtures/js+ts/src/typed.ts
+++ b/test/fixtures/js+ts/src/typed.ts
@@ -1,0 +1,3 @@
+export const hello = (name:string):string => {
+  return `Hello ${name}`
+}

--- a/test/lint.js
+++ b/test/lint.js
@@ -161,4 +161,9 @@ describe('lint', () => {
 
     await expect(lint({ silent: true })).to.eventually.be.rejectedWith('Lint errors')
   })
+
+  it('should lint ts and js with different parsers rules', async () => {
+    process.chdir(path.join(__dirname, './fixtures/js+ts/'))
+    await lint()
+  })
 })


### PR DESCRIPTION
Without this change `aegir` either uses esmodule parse rules or script based parse rules, which causes issues with repos that contain both `.ts` and `.js` files regardless of `--ts` option. Without `--ts` option it complains about `import` statements with `--ts` option it complains about use of unnecessary `'use strict'`.

This change introduces config for eslint that overrides based on file type using js config for js files and ts config for ts files. It also adds a test case which fails without this change.

Fixes https://github.com/ipfs/aegir/issues/618