### PR TITLE
feat: add support for the mocha --invert flag

### DIFF
--- a/src/config/karma.conf.js
+++ b/src/config/karma.conf.js
@@ -55,7 +55,8 @@ const karmaConfig = (config, argv) => {
     reporter: 'spec',
     timeout: argv.timeout ? Number(argv.timeout) : 5000,
     bail: argv.bail,
-    grep: argv.grep
+    grep: argv.grep,
+    invert: argv.invert
   }
 
   const karmaEntry = `${__dirname}/karma-entry.js`

--- a/src/test/browser.js
+++ b/src/test/browser.js
@@ -13,6 +13,7 @@ module.exports = (argv, execaOptions) => {
   const files = argv.files ? ['--files-custom', ...argv.files] : []
   const verbose = argv.verbose ? ['--log-level', 'debug'] : ['--log-level', 'error']
   const grep = argv.grep ? ['--grep', argv.grep] : []
+  const invert = argv.invert ? ['--invert'] : []
   const progress = argv.progress ? ['--progress', argv.progress] : []
   const bail = argv.bail ? ['--bail', argv.bail] : []
   const timeout = argv.timeout ? ['--timeout', argv.timeout] : []
@@ -27,6 +28,7 @@ module.exports = (argv, execaOptions) => {
           ...files,
           ...verbose,
           ...grep,
+          ...invert,
           ...progress,
           ...input,
           ...bail,

--- a/src/test/electron.js
+++ b/src/test/electron.js
@@ -10,6 +10,7 @@ module.exports = (argv) => {
   const files = argv.files.length ? [...argv.files] : ['test/**/*.spec.{js,ts}']
   const verbose = argv.verbose ? ['--log-level', 'debug'] : ['--log-level', 'error']
   const grep = argv.grep ? ['--grep', argv.grep] : []
+  const invert = argv.invert ? ['--invert'] : []
   const progress = argv.progress ? ['--reporter=progress'] : []
   const bail = argv.bail ? ['--bail', argv.bail] : []
   const timeout = argv.timeout ? ['--timeout', argv.bail] : []
@@ -25,6 +26,7 @@ module.exports = (argv) => {
         ...watch,
         ...verbose,
         ...grep,
+        ...invert,
         ...progress,
         ...bail,
         ...timeout,

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -40,6 +40,10 @@ function testNode (ctx, execaOptions) {
     args.push(`--grep=${ctx.grep}`)
   }
 
+  if (ctx.invert) {
+    args.push('--invert')
+  }
+
   if (ctx.files && ctx.files.length > 0) {
     files = ctx.files
   }


### PR DESCRIPTION
The --invert flag requires `--grep` be used. This makes it easy to skip certain tests via the cli.

`npx aegir test --grep "test to skip" --invert`