### PR TITLE
fix: fix electron timeout and renderer console.assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "cors": "^2.8.5",
     "cosmiconfig": "^7.0.0",
     "dirty-chai": "^2.0.1",
-    "electron-mocha": "^9.3.2",
+    "electron-mocha": "9.3.1",
     "eslint": "^7.11.0",
     "eslint-config-ipfs": "^0.1.0",
     "execa": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "cors": "^2.8.5",
     "cosmiconfig": "^7.0.0",
     "dirty-chai": "^2.0.1",
-    "electron-mocha": "9.3.1",
+    "electron-mocha": "9.3.0",
     "eslint": "^7.11.0",
     "eslint-config-ipfs": "^0.1.0",
     "execa": "^4.1.0",

--- a/src/test/electron.js
+++ b/src/test/electron.js
@@ -13,7 +13,7 @@ module.exports = (argv) => {
   const invert = argv.invert ? ['--invert'] : []
   const progress = argv.progress ? ['--reporter=progress'] : []
   const bail = argv.bail ? ['--bail', argv.bail] : []
-  const timeout = argv.timeout ? ['--timeout', argv.bail] : []
+  const timeout = argv.timeout ? ['--timeout', argv.timeout] : []
   const renderer = argv.renderer ? ['--renderer'] : []
   const ts = argv.ts ? ['--require', fromAegir('src/config/register.js')] : []
 


### PR DESCRIPTION
pin electron mocha to 9.3.0 to fix missing console.assert 

related:
https://github.com/jprichardson/electron-mocha/issues/173