### PR TITLE
fix: prepare scripts when aegir gets hoisted

### DIFF
--- a/src/ts/index.js
+++ b/src/ts/index.js
@@ -15,10 +15,7 @@ module.exports = async (argv) => {
 
   if (argv.preset === 'config') {
     const extendsConfig = `{
-    "extends": "./${path.relative(
-        process.cwd(),
-        require.resolve('aegir/src/config/tsconfig.aegir.json')
-    )}",
+    "extends": "aegir/src/config/tsconfig.aegir.json",
     "compilerOptions": {
         "outDir": "dist"
     },


### PR DESCRIPTION
I'm not sure what was the reason to use relative path to the base config, but it brakes `"prepare": "aegir ts -p types` scripts when dep is coming from git url and package itself depends on `aegir` because it gets hoisted and base config isn't found.

This seems to resolve that issue.