### PR TITLE
Update ts-jsdoc.md

### DIFF
--- a/md/ts-jsdoc.md
+++ b/md/ts-jsdoc.md
@@ -11,7 +11,15 @@ Add types configuration to your package.json:
 ```json
 "types": "dist/src/index.d.ts",
 "typesVersions": {
-  "*": { "src/*": ["dist/src/*", "dist/src/*/index"] }
+  "*": {
+    "src/*": [
+      "dist/src/*", 
+      "dist/src/*/index"
+    ],
+    "src/": [
+      "dist/src/index"
+    ]
+  }
 },
 ```
 `types` will tell `tsc` where to look for the entry point type declarations and `typeVersions` for every other files inside the `src` folder.


### PR DESCRIPTION
Unfortunately TS still generates strange imports paths in various places e.g. `'multihashes'` is turned in the generated types into `multihashes/src/` which than is not caught by our types mapping. Which we could catch with additional mapping proposed by this pull request.