### PR TITLE
feat: support vendored types and improvements to build and ts cmds

### DIFF
--- a/cmds/build.js
+++ b/cmds/build.js
@@ -1,4 +1,9 @@
 'use strict'
+
+/**
+ * @typedef {import("yargs").Argv}Argv
+ * @typedef {import("yargs").Arguments}Arguments
+ */
 const EPILOG = `
 Output files will go into a "./dist" folder.
 Supports options forwarding with '--' for more info check https://webpack.js.org/api/cli/
@@ -6,18 +11,35 @@ Supports options forwarding with '--' for more info check https://webpack.js.org
 module.exports = {
   command: 'build',
   desc: 'Builds a browser bundle and TS type declarations from the `src` folder.',
+  /**
+   * @param {Argv} yargs
+   */
   builder: (yargs) => {
     yargs
       .epilog(EPILOG)
       .options({
+        bundle: {
+          type: 'boolean',
+          describe: 'Build the JS standalone bundle.',
+          default: true
+        },
         bundlesize: {
           alias: 'b',
           type: 'boolean',
           describe: 'Analyse bundle size. Default threshold is 100kB, you can override that in `.aegir.js` with the property `bundlesize.maxSize`.',
           default: false
+        },
+        types: {
+          type: 'boolean',
+          describe: 'Build the Typescripts type declarations.',
+          default: true
         }
       })
   },
+  /**
+   *
+   * @param {Arguments} argv
+   */
   handler (argv) {
     const build = require('../src/build')
     return build(argv)

--- a/cmds/build.js
+++ b/cmds/build.js
@@ -1,8 +1,8 @@
 'use strict'
 
 /**
- * @typedef {import("yargs").Argv}Argv
- * @typedef {import("yargs").Arguments}Arguments
+ * @typedef {import("yargs").Argv} Argv
+ * @typedef {import("yargs").Arguments} Arguments
  */
 const EPILOG = `
 Output files will go into a "./dist" folder.

--- a/cmds/ts.js
+++ b/cmds/ts.js
@@ -3,7 +3,7 @@
 const EPILOG = `
 Presets:
 \`check\`       Runs the type checker with your local config (without writing any files). . 
-\`types\`       Emits type declarations for \`['src/**/*', 'package.json']\` to \`dist\` folder.
+\`types\`       Emits type declarations to \`dist\` folder.
 \`docs\`        Generates documentation based on type declarations to the \`docs\` folder.
 \`config\`      Prints base config to stdout.
 

--- a/md/ts-jsdoc.md
+++ b/md/ts-jsdoc.md
@@ -26,7 +26,7 @@ Run `aegir ts --help` and check the help text. There's presets for common TS use
 ```md
 Presets:
 `check`       Runs the type checker with your local config and doesn't not emit output.
-`types`       Emits type declarations for `['src/**/*', 'package.json']` to `dist` folder.
+`types`       Emits type declarations to `dist` folder.
 `docs`        Generates documentation based on type declarations to the `docs` folder.
 `config`      Prints base config to stdout.
 ```

--- a/md/ts-jsdoc.md
+++ b/md/ts-jsdoc.md
@@ -44,16 +44,47 @@ When installing a dependency from a git url (ie. PRs depending on other PRs) the
 ```
 > `yarn` needs a .npmignore file to properly install dependencies with `prepare` scripts that create extra files that need to be packed in.
 
-## Adding types with JSDoc
-
-Typescript can infere lots of the types without any help, but you can improve your code types by using just JSDoc for that follow the official TS documentation https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html. 
-
 ## Must read references
 [10 Insights from Adopting TypeScript at Scale](https://www.techatbloomberg.com/blog/10-insights-adopting-typescript-at-scale/)  
 [Typescript official performance notes](https://github.com/microsoft/TypeScript/wiki/Performance)  
 [TypeScript: Don’t Export const enums](https://ncjamieson.com/dont-export-const-enums/)  
 [TypeScript: Prefer Interfaces](https://ncjamieson.com/prefer-interfaces/)
 
+
+## Adding types with JSDoc
+
+Typescript can infere lots of the types without any help, but you can improve your code types by using just JSDoc for that follow the official TS documentation https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html. 
+
+## Manage dependencies types
+When dependencies don't publish types you have two options.
+
+### NPM from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
+```bash
+npm install @types/tape
+```
+
+### Vendor type declarations
+Create a `types` folder at the root of your project to keep all your vendored types. Inside create one folder per dependency using the dependency name as the folder name and inside a create `index.d.ts` file with the types. 
+
+Tell TS where to look for types when a package doesn't publish them.
+```json
+"compilerOptions": {
+  "baseUrl": "./",
+  "paths": {
+    "*": ["./types/*"]
+  }
+}
+"include": [
+  ...
+  "types"
+]
+```
+
+> Scoped packages folder name need to use `__` instead of `/`, ie. the folder for `@pre-bundle/tape` would be `pre-bundle__tape`. 
+
+Aegir will copy the types folder to the `dist` folder (ie. `dist/types`) when you build or run the types typescript preset. This way all your types, vendored and from source, will be published without broken imports. 
+
+Reference: https://github.com/voxpelli/types-in-js/discussions/7#discussion-58634
 
 
 ### Rules for optimal type declarations and documentation
@@ -112,7 +143,7 @@ exports.IPFS = IPFS
 ```
 
 #### 3. Use a `types.ts` file
-When writing types JSDoc can sometimes be cumbersome, impossible, it can output weird type declarations or even broken documentation. Most of these problems can be solved by defining some complex types in typescript in a `types.ts` file.
+When writing types JSDoc can sometimes be cumbersome, impossible, it can output weird type declarations or even broken documentation. Most of these problems can be solved by defining some complex types in typescript in a `types.ts` file. 
 
 ```ts
 // types.ts
@@ -124,6 +155,16 @@ export type IntersectionType = Type1 & Type2
 /** @type { import('./types').IntersectionType } */
 const list
 ```
+You can also organise your source types in the same way as [vendored types](#vendor-type-declarations). 
+
+Create a folder inside the `types` folder called `self` or the package name. Then you can import like you would a third party type.
+
+```js
+/**
+ * @typedef {import('self').CustomOptions} CustomOptions
+ * /
+```
+
 
 #### 4. JSDoc comments bad parsing
 Some TS tooling may have problems parsing comments if they are not very well divided.

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/chai-subset": "^1.3.3",
     "@types/dirty-chai": "^2.0.2",
     "@types/mocha": "^8.2.0",
-    "@types/node": "^14.14.13",
+    "@types/node": "^14.14.20",
     "aegir-typedoc-theme": "^0.1.0",
     "babel-loader": "^8.2.2",
     "buffer": "^6.0.3",
@@ -115,7 +115,7 @@
     "mocha": "^8.2.1",
     "npm-package-json-lint": "^5.1.0",
     "nyc": "^15.1.0",
-    "ora": "^5.1.0",
+    "ora": "^5.2.0",
     "p-map": "^4.0.0",
     "pascalcase": "^1.0.0",
     "polka": "^0.5.2",
@@ -138,10 +138,10 @@
     "yargs-parser": "^20.2.3"
   },
   "devDependencies": {
-    "@types/fs-extra": "^9.0.5",
+    "@types/fs-extra": "^9.0.6",
     "@types/polka": "^0.5.1",
     "@types/yargs": "^15.0.12",
-    "electron": "^11.1.0",
+    "electron": "^11.1.1",
     "iso-url": "^1.0.0",
     "mock-require": "^3.0.2",
     "sinon": "^9.2.2"

--- a/package.json
+++ b/package.json
@@ -138,7 +138,9 @@
     "yargs-parser": "^20.2.3"
   },
   "devDependencies": {
+    "@types/fs-extra": "^9.0.5",
     "@types/polka": "^0.5.1",
+    "@types/yargs": "^15.0.12",
     "electron": "^11.1.0",
     "iso-url": "^1.0.0",
     "mock-require": "^3.0.2",

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -24,42 +24,43 @@ module.exports = async (argv) => {
   // Clean dist
   await del(path.join(process.cwd(), 'dist'))
 
-  // Run webpack
-  const webpack = await execa('webpack-cli', [
-    ...webpackConfig,
-    ...progress,
-    ...input,
-    ...forwardOptions
-  ], {
-    env: {
-      NODE_ENV: process.env.NODE_ENV || 'production',
-      AEGIR_BUILD_ANALYZE: argv.bundlesize,
-      AEGIR_NODE: argv.node,
-      AEGIR_TS: argv.ts
-    },
-    localDir: path.join(__dirname, '../..'),
-    preferLocal: true,
-    stdio: 'inherit'
-  })
+  if (argv.bundle) {
+    // Run webpack
+    await execa('webpack-cli', [
+      ...webpackConfig,
+      ...progress,
+      ...input,
+      ...forwardOptions
+    ], {
+      env: {
+        NODE_ENV: process.env.NODE_ENV || 'production',
+        AEGIR_BUILD_ANALYZE: argv.bundlesize,
+        AEGIR_NODE: argv.node,
+        AEGIR_TS: argv.ts
+      },
+      localDir: path.join(__dirname, '../..'),
+      preferLocal: true,
+      stdio: 'inherit'
+    })
 
-  if (argv.bundlesize) {
-    const stats = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'dist/stats.json')))
-    const gzip = await gzipSize(path.join(stats.outputPath, stats.assets[0].name))
-    const maxsize = bytes(config.bundlesize.maxSize)
-    const diff = gzip - maxsize
+    if (argv.bundlesize) {
+      const stats = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'dist/stats.json')))
+      const gzip = await gzipSize(path.join(stats.outputPath, stats.assets[0].name))
+      const maxsize = bytes(config.bundlesize.maxSize)
+      const diff = gzip - maxsize
 
-    console.log('Use http://webpack.github.io/analyse/ to load "./dist/stats.json".')
-    console.log(`Check previous sizes in https://bundlephobia.com/result?p=${pkg.name}@${pkg.version}`)
+      console.log('Use http://webpack.github.io/analyse/ to load "./dist/stats.json".')
+      console.log(`Check previous sizes in https://bundlephobia.com/result?p=${pkg.name}@${pkg.version}`)
 
-    if (diff > 0) {
-      throw new Error(`${bytes(gzip)} (▲${bytes(diff)} / ${bytes(maxsize)})`)
-    } else {
-      console.log(`${bytes(gzip)} (▼${bytes(diff)} / ${bytes(maxsize)})`)
+      if (diff > 0) {
+        throw new Error(`${bytes(gzip)} (▲${bytes(diff)} / ${bytes(maxsize)})`)
+      } else {
+        console.log(`${bytes(gzip)} (▼${bytes(diff)} / ${bytes(maxsize)})`)
+      }
     }
   }
 
-  if (hasTsconfig) {
+  if (argv.types && hasTsconfig) {
     await tsCmd({ preset: 'types' })
   }
-  return webpack
 }

--- a/src/ts/index.js
+++ b/src/ts/index.js
@@ -8,8 +8,8 @@ const merge = require('merge-options')
 const { fromRoot, fromAegir, hasFile, readJson } = require('../utils')
 const hasConfig = hasFile('tsconfig.json')
 /**
- * @typedef {import("yargs").Argv}Argv
- * @typedef {import("yargs").Arguments}Arguments
+ * @typedef {import("yargs").Argv} Argv
+ * @typedef {import("yargs").Arguments} Arguments
  */
 
 /**

--- a/src/ts/typedoc-plugin.js
+++ b/src/ts/typedoc-plugin.js
@@ -23,12 +23,16 @@ module.exports = function (PluginHost) {
         // reflection.kind = 2
       }
 
-      if (pkgJson && reflection.name.includes('types/src/index.d.ts')) {
+      if (pkgJson && reflection.name.includes('dist/src/index.d.ts')) {
         reflection.name = '\u0000' + pkgJson.name.charAt(0) + pkgJson.name.slice(1)
       }
 
       if (pkgJson && reflection.name.includes('.d.ts')) {
         reflection.name = reflection.name.replace('.d.ts', '.js')
+      }
+
+      if (pkgJson && reflection.name.includes('dist/')) {
+        reflection.name = reflection.name.replace('dist/', '')
       }
     }
   })


### PR DESCRIPTION
- support vendored types
- add --bundle and --types to the build cmd so we can disable either
- ts types preset doesn't overide `include` anymore just excludes the test folder
- ts types preset copies types folder to dist so it can be published
- ts docs preset reworked to use the types preset instead of having a custom config
- add docs about vendored types