### PR TITLE
feat: rename --ts flag to --ts-repo and fix ts repo support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -46,12 +46,12 @@ cli
     describe: 'Flag to control if bundler should inject node globals or built-ins.',
     default: userConfig.node
   })
-  .options('ts', {
+  .options('ts-repo', {
     type: 'boolean',
-    describe: 'Enable support for Typescript',
-    default: userConfig.ts // needs to be changed to another name to not conflict with the ts cmd options
+    describe: 'Enable support for Typescript repos.',
+    default: userConfig.tsRepo
   })
-  .group(['help', 'version', 'debug', 'node', 'ts'], 'Global Options:')
+  .group(['help', 'version', 'debug', 'node', 'ts-repo'], 'Global Options:')
   .demandCommand(1, 'You need at least one command.')
   .wrap(cli.terminalWidth())
   .parserConfiguration({ 'populate--': true })

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -39,7 +39,7 @@ module.exports = async (argv) => {
         NODE_ENV: process.env.NODE_ENV || 'production',
         AEGIR_BUILD_ANALYZE: argv.bundlesize,
         AEGIR_NODE: argv.node,
-        AEGIR_TS: argv.ts
+        AEGIR_TS: argv.tsRepo
       },
       localDir: path.join(__dirname, '../..'),
       preferLocal: true,

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -54,7 +54,7 @@ const config = (searchFrom) => {
       // global options
       debug: false,
       node: false,
-      ts: false,
+      tsRepo: false,
       // old options
       webpack: {},
       karma: {},

--- a/src/test/browser.js
+++ b/src/test/browser.js
@@ -41,7 +41,7 @@ module.exports = (argv, execaOptions) => {
               NODE_ENV: process.env.NODE_ENV || 'test',
               AEGIR_RUNNER: argv.webworker ? 'webworker' : 'browser',
               AEGIR_NODE: argv.node,
-              AEGIR_TS: argv.ts,
+              AEGIR_TS: argv.tsRepo,
               IS_WEBPACK_BUILD: true,
               ...hook.env
             },

--- a/src/test/electron.js
+++ b/src/test/electron.js
@@ -15,7 +15,7 @@ module.exports = (argv) => {
   const bail = argv.bail ? ['--bail', argv.bail] : []
   const timeout = argv.timeout ? ['--timeout', argv.timeout] : []
   const renderer = argv.renderer ? ['--renderer'] : []
-  const ts = argv.ts ? ['--require', fromAegir('src/config/register.js')] : []
+  const ts = argv.tsRepo ? ['--require', fromAegir('src/config/register.js')] : []
 
   return hook('browser', 'pre')(argv.userConfig)
     .then((hook = {}) => Promise.all([hook, getElectron()]))
@@ -43,7 +43,7 @@ module.exports = (argv) => {
           NODE_ENV: process.env.NODE_ENV || 'test',
           AEGIR_RUNNER: argv.renderer ? 'electron-renderer' : 'electron-main',
           ELECTRON_PATH: electronPath,
-          AEGIR_TS: argv.ts,
+          AEGIR_TS: argv.tsRepo,
           ...hook.env
         }
       })

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -9,17 +9,17 @@ const DEFAULT_TIMEOUT = global.DEFAULT_TIMEOUT || 5 * 1000
 
 /** @typedef { import("execa").Options} ExecaOptions */
 
-function testNode (ctx, execaOptions) {
+function testNode (argv, execaOptions) {
   let exec = 'mocha'
   const env = {
     NODE_ENV: 'test',
     AEGIR_RUNNER: 'node',
-    AEGIR_TS: ctx.ts
+    AEGIR_TS: argv.tsRepo
   }
-  const timeout = ctx.timeout || DEFAULT_TIMEOUT
+  const timeout = argv.timeout || DEFAULT_TIMEOUT
 
   let args = [
-    ctx.progress && '--reporter=progress',
+    argv.progress && '--reporter=progress',
     '--ui', 'bdd',
     '--timeout', timeout
   ].filter(Boolean)
@@ -29,48 +29,48 @@ function testNode (ctx, execaOptions) {
     'test/**/*.spec.{js,ts}'
   ]
 
-  if (ctx.colors) {
+  if (argv.colors) {
     args.push('--colors')
   } else {
     args.push('--no-colors')
   }
 
-  if (ctx.grep) {
-    args.push(`--grep=${ctx.grep}`)
+  if (argv.grep) {
+    args.push(`--grep=${argv.grep}`)
   }
 
-  if (ctx.invert) {
+  if (argv.invert) {
     args.push('--invert')
   }
 
-  if (ctx.files && ctx.files.length > 0) {
-    files = ctx.files
+  if (argv.files && argv.files.length > 0) {
+    files = argv.files
   }
 
-  if (ctx.verbose) {
+  if (argv.verbose) {
     args.push('--verbose')
   }
 
-  if (ctx.watch) {
+  if (argv.watch) {
     args.push('--watch')
   }
 
-  if (ctx.exit) {
+  if (argv.exit) {
     args.push('--exit')
   }
 
-  if (ctx.bail) {
+  if (argv.bail) {
     args.push('--bail')
   }
 
-  if (ctx.ts) {
+  if (argv.tsRepo) {
     args.push(...['--require', fromAegir('src/config/register.js')])
   }
 
   const postHook = hook('node', 'post')
   const preHook = hook('node', 'pre')
 
-  if (ctx['100']) {
+  if (argv['100']) {
     args = [
       '--check-coverage',
       '--branches=100',
@@ -82,7 +82,7 @@ function testNode (ctx, execaOptions) {
     exec = 'nyc'
   }
 
-  return preHook(ctx)
+  return preHook(argv)
     .then((hook = {}) => {
       return execa(exec,
         args.concat(files.map((p) => path.normalize(p))),
@@ -100,7 +100,7 @@ function testNode (ctx, execaOptions) {
         )
       )
     })
-    .then(() => postHook(ctx))
+    .then(() => postHook(argv))
 }
 
 module.exports = testNode


### PR DESCRIPTION
- we need to rename the flag to avoid conflicts in the options object with the `ts` cmd
- generate js files in TS repos