### PR TITLE
feat: ts, build, docs and lint improvements

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -69,7 +69,7 @@ const args = cli.fail((msg, err, yargs) => {
     if (args.debug) {
       console.error('\n', err)
     } else {
-      console.error(chalk.red(err.message))
+      console.error(err.message)
     }
   }
 

--- a/cmds/build.js
+++ b/cmds/build.js
@@ -29,6 +29,12 @@ module.exports = {
           describe: 'Analyse bundle size. Default threshold is 100kB, you can override that in `.aegir.js` with the property `bundlesize.maxSize`.',
           default: userConfig.build.bundlesize
         },
+        bundlesizeMax: {
+          alias: 'b',
+          type: 'boolean',
+          describe: 'Max threshold for the bundle size.',
+          default: userConfig.build.bundlesizeMax
+        },
         types: {
           type: 'boolean',
           describe: 'Build the Typescripts type declarations.',

--- a/cmds/ts.js
+++ b/cmds/ts.js
@@ -1,4 +1,5 @@
 'use strict'
+const { userConfig } = require('../src/config/user')
 
 const EPILOG = `
 Presets:
@@ -23,12 +24,13 @@ module.exports = {
           type: 'string',
           choices: ['config', 'check', 'types'],
           describe: 'Preset to run',
-          alias: 'p'
+          alias: 'p',
+          default: userConfig.ts.preset
         },
         include: {
           type: 'array',
           describe: 'Values are merged into the local TS config include property.',
-          default: []
+          default: userConfig.ts.include
         }
       })
   },

--- a/package.json
+++ b/package.json
@@ -138,7 +138,9 @@
   },
   "devDependencies": {
     "@types/bytes": "^3.1.0",
+    "@types/eslint": "^7.2.6",
     "@types/fs-extra": "^9.0.6",
+    "@types/gh-pages": "^3.0.0",
     "@types/listr": "^0.14.2",
     "@types/polka": "^0.5.2",
     "@types/semver": "^7.3.4",

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -5,6 +5,14 @@ const { lilconfigSync } = require('lilconfig')
 const merge = require('merge-options')
 const utils = require('../utils')
 
+/**
+ * @typedef {import("./../types").Options} Options
+ */
+
+/**
+ *
+ * @param {*} hooks
+ */
 function normalizeHooks (hooks = {}) {
   const result = {
     browser: {
@@ -29,6 +37,12 @@ function normalizeHooks (hooks = {}) {
   return merge(result, hooks)
 }
 
+/**
+ * Search for local user config
+ *
+ * @param {string | undefined} [searchFrom]
+ * @returns {Options}
+ */
 const config = (searchFrom) => {
   let userConfig
   try {
@@ -49,6 +63,8 @@ const config = (searchFrom) => {
     console.error(err)
     throw new Error('Error finding your config file.')
   }
+
+  /** @type {Options} */
   const conf = merge(
     {
       // global options
@@ -60,14 +76,11 @@ const config = (searchFrom) => {
       karma: {},
       hooks: {},
       entry: utils.fromRoot('src', 'index.js'),
-      bundlesize: {
-        path: './dist/index.min.js',
-        maxSize: '100kB'
-      },
       // build cmd options
       build: {
         bundle: true,
         bundlesize: false,
+        bundlesizeMax: '100kB',
         types: true
       },
       // linter cmd options
@@ -91,6 +104,10 @@ const config = (searchFrom) => {
       docs: {
         publish: false,
         entryPoint: 'src/index.js'
+      },
+      ts: {
+        preset: undefined,
+        include: []
       }
     },
     userConfig,

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -1,11 +1,12 @@
 'use strict'
 
 const path = require('path')
+const pascalcase = require('pascalcase')
 const webpack = require('webpack')
 const merge = require('webpack-merge')
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 const TerserPlugin = require('terser-webpack-plugin')
-const { fromRoot, pkg, paths, getLibraryName } = require('../utils')
+const { fromRoot, pkg, paths } = require('../utils')
 const { userConfig } = require('./user')
 const isProduction = process.env.NODE_ENV === 'production'
 const isTSEnable = process.env.AEGIR_TS === 'true'
@@ -24,10 +25,10 @@ const base = (env, argv) => {
     mode: isProduction ? 'production' : 'development',
     entry: [isTSEnable ? fromRoot('src', 'index.ts') : fromRoot('src', 'index.js')],
     output: {
-      path: fromRoot(paths.dist),
+      path: paths.dist,
       filename: filename,
       sourceMapFilename: filename + '.map',
-      library: getLibraryName(pkg.name),
+      library: pascalcase(pkg.name),
       libraryTarget: 'umd',
       globalObject: 'self', // Use `self` as `window` doesn't not exist within a Service/Web Worker context
       devtoolModuleFilenameTemplate: info => 'file:' + encodeURI(info.absoluteResourcePath)
@@ -38,7 +39,7 @@ const base = (env, argv) => {
           oneOf: [
             {
               test: /\.(js|ts)$/,
-              include: fromRoot(paths.src),
+              include: paths.src,
               use: {
                 loader: require.resolve('babel-loader'),
                 options: {

--- a/src/release/bump.js
+++ b/src/release/bump.js
@@ -3,12 +3,16 @@
 const semver = require('semver')
 const fs = require('fs-extra')
 
-const { getPathToPkg } = require('../utils')
+const { paths } = require('../utils')
 
+/**
+ * @param {{ type: any; preid: any; }} ctx
+ * @param {{ title: string; }} task
+ */
 function bump (ctx, task) {
   const { type, preid } = ctx
 
-  return fs.readJson(getPathToPkg())
+  return fs.readJson(paths.package)
     .then((pkg) => {
       const version = pkg.version
       const newVersion = semver.inc(version, type, preid)
@@ -16,7 +20,7 @@ function bump (ctx, task) {
       task.title += `: v${version} -> v${newVersion}`
 
       pkg.version = newVersion
-      return fs.writeJson(getPathToPkg(), pkg, { spaces: 2 })
+      return fs.writeJson(paths.package, pkg, { spaces: 2 })
     })
 }
 

--- a/src/release/commit.js
+++ b/src/release/commit.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const git = require('simple-git/promise')(process.cwd())
-const { pkgVersion } = require('../utils')
+const { pkg } = require('../utils')
 
 const files = ['package.json', 'CHANGELOG.md']
 
@@ -9,7 +9,7 @@ async function commit () {
   await git.add(files)
 
   await git.commit(
-    `chore: release version v${await pkgVersion()}`,
+    `chore: release version v${pkg.version}`,
     files
   )
 }

--- a/src/release/contributors.js
+++ b/src/release/contributors.js
@@ -2,7 +2,7 @@
 
 const git = require('simple-git/promise')(process.cwd())
 const execa = require('execa')
-const { getPathToPkg } = require('../utils')
+const { paths } = require('../utils')
 
 const contributors = async () => {
   await execa('git-authors-cli', ['--print', 'false'])
@@ -15,9 +15,9 @@ const contributors = async () => {
 
   await git.commit(
     'chore: update contributors',
-    getPathToPkg(),
+    paths.package,
     {
-      '--no-verify': true
+      '--no-verify': null
     }
   )
 }

--- a/src/release/tag.js
+++ b/src/release/tag.js
@@ -2,10 +2,10 @@
 
 const git = require('simple-git/promise')(process.cwd())
 
-const { pkgVersion } = require('../utils')
+const { pkg } = require('../utils')
 
 async function tag () {
-  await git.addTag(`v${await pkgVersion()}`)
+  await git.addTag(`v${pkg.version}`)
 }
 
 module.exports = tag

--- a/src/ts/index.js
+++ b/src/ts/index.js
@@ -10,8 +10,12 @@ const hasConfig = hasFile('tsconfig.json')
 /**
  * @typedef {import("yargs").Argv} Argv
  * @typedef {import("yargs").Arguments} Arguments
+ * @typedef {import("../types").GlobalOptions} GlobalOptions
+ * @typedef {import("../types").TSOptions} TSOptions
+ * @typedef {import("../types").BuildOptions} BuildOptions
+ *
  * @typedef {Object} Options
- * @property {"config" | "check" | "types" | "docs"} preset
+ * @property {"config" | "check" | "types"} preset
  * @property {string[]} forwardOptions - Extra options to forward to the backend
  * @property {string[]} extraInclude - Extra include files for the TS Config
  * @property {boolean} tsRepo - Typescript repo support.
@@ -20,7 +24,7 @@ const hasConfig = hasFile('tsconfig.json')
 /**
  * Typescript command
  *
- * @param {any} argv
+ * @param {GlobalOptions & TSOptions & BuildOptions} argv
  */
 module.exports = async (argv) => {
   /** @type {Options} */
@@ -120,7 +124,7 @@ const types = async (userTSConfig, opts) => {
         userTSConfig,
         {
           compilerOptions: {
-            noEmit: !opts.tsRepo,
+            noEmit: false,
             emitDeclarationOnly: !opts.tsRepo,
             declaration: true,
             declarationMap: true

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ interface GlobalOptions {
   tsRepo: boolean
 
   /**
-   * Foward options to pass to the backend command populated by yargs parser
+   * Forward options to pass to the backend command populated by yargs parser
    */
   '--'?: string[]
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,117 @@
+
+/**
+ * Options for CLI and local file config
+ *
+ *
+ */
+interface Options extends GlobalOptions {
+
+  /**
+   * Options for the `build` command
+   */
+  build: BuildOptions
+
+  /**
+   * Options for the `ts` command
+   */
+  ts: TSOptions
+
+  /**
+   * Options for the `docs` command
+   */
+  docs: DocsOptions
+  /**
+   * Options for the `lint` command
+   */
+  lint: LintOptions
+}
+
+interface GlobalOptions {
+  /**
+   * Show debug output.
+   */
+  debug: boolean
+  /**
+   * Flag to control if bundler should inject node globals or built-ins.
+   */
+  node: boolean
+  /**
+   * Enable support for Typescript repos.
+   */
+  tsRepo: boolean
+
+  /**
+   * Foward options to pass to the backend command populated by yargs parser
+   */
+  '--'?: string[]
+
+  /**
+   * CLI Input
+   */
+  '_'?: string
+}
+
+interface BuildOptions {
+  /**
+   * Build the JS standalone bundle.
+   */
+  bundle: boolean
+  /**
+   * Analyse bundle size. Default threshold is 100kB, you can override that in `.aegir.js` with the property `bundlesize.maxSize`.
+   */
+  bundlesize: boolean
+  /**
+   * Max threshold for the bundle size.
+   */
+  bundlesizeMax: string
+  /**
+   * Build the Typescripts type declarations.
+   */
+  types: boolean
+}
+
+interface TSOptions {
+  /**
+   * Preset to run.
+   */
+  preset: 'config' | 'check' | 'types'
+  /**
+   * Values are merged into the local TS config include property.
+   */
+  include: string[]
+}
+
+interface DocsOptions {
+  /**
+   * Publish to GitHub Pages
+   */
+  publish: boolean
+  /**
+   * Specifies the entry points to be documented by TypeDoc. TypeDoc will examine the exports of these files and create documentation according to the exports. Either files or directories may be specified. If a directory is specified, all source files within the directory will be included as an entry point.
+   */
+  entryPoint: string
+}
+
+interface LintOptions {
+  /**
+   * Automatically fix errors if possible.
+   */
+  fix: boolean
+  /**
+   * Files to lint.
+   */
+  files: string[]
+  /**
+   * Disable eslint output.
+   */
+  silent: boolean
+}
+
+export type {
+  Options,
+  GlobalOptions,
+  BuildOptions,
+  TSOptions,
+  DocsOptions,
+  LintOptions
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -94,7 +94,7 @@ exports.hook = (env, key) => (ctx) => {
 
 /**
  * @param {string} command
- * @param { string[] | undefined} args
+ * @param {string[] | undefined} args
  * @param {any} options
  */
 exports.exec = (command, args, options = {}) => {

--- a/test/lint.js
+++ b/test/lint.js
@@ -26,22 +26,6 @@ const setupProjectWithDeps = deps => setupProject({
   })
 })
 
-const dependenciesShouldPassLinting = (deps) => {
-  return setupProjectWithDeps(deps)
-    .then(() => lint(userConfig.lint))
-}
-
-const dependenciesShouldFailLinting = (deps) => {
-  return setupProjectWithDeps(deps)
-    .then(() => lint(userConfig.lint))
-    .then(() => {
-      throw new Error('Should have failed!')
-    })
-    .catch(error => {
-      expect(error.message).to.contain('Dependency version errors')
-    })
-}
-
 const projectShouldPassLint = async (project) => {
   await setupProject(project)
   await lint(userConfig.lint)
@@ -76,88 +60,6 @@ describe('lint', () => {
     return lint({ fix: false, silent: true, files: userConfig.lint.files })
   })
 
-  it('succeeds when package.json contains dependencies with good versions', function () {
-    return dependenciesShouldPassLinting({
-      'some-unstable-dep': '~0.0.1',
-      'some-dev-dep': '^0.1.0',
-      'some-other-dev-dep': '~0.1.0',
-      'some-stable-dep': '^1.0.0',
-      'some-pinned-dep': '1.0.0'
-    })
-  })
-
-  it('fails when package.json contains dependencies with carets for unstable deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '^0.0.1'
-    })
-  })
-
-  it('fails when package.json contains dependencies with <= for unstable deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '<=0.0.1'
-    })
-  })
-
-  it('fails when package.json contains dependencies with > for unstable deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '>0.0.1'
-    })
-  })
-
-  it('fails when package.json contains dependencies with < for unstable deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '<0.0.1'
-    })
-  })
-
-  it('fails when package.json contains dependencies with >= for unstable deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '>=0.0.1'
-    })
-  })
-
-  it('fails when package.json contains dependencies with <= for development deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '<=0.1.0'
-    })
-  })
-
-  it('fails when package.json contains dependencies with > for development deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '>0.1.0'
-    })
-  })
-
-  it('fails when package.json contains dependencies with < for development deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '<0.1.0'
-    })
-  })
-
-  it('fails when package.json contains dependencies with >= for development deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '>=0.1.0'
-    })
-  })
-
-  it('fails when package.json contains dependencies with tildes for stable deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '~1.0.0'
-    })
-  })
-
-  it('fails when package.json contains dependencies with > for stable deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '>1.0.0'
-    })
-  })
-
-  it('fails when package.json contains dependencies with < for stable deps', function () {
-    return dependenciesShouldFailLinting({
-      'some-dep': '<1.0.0'
-    })
-  })
-
   it('should pass in user defined path globs', () => {
     const dir = `test-${Date.now()}`
     return setupProjectWithDeps([])
@@ -167,7 +69,11 @@ describe('lint', () => {
         fs.mkdirSync(dir)
         fs.writeFileSync(`${dir}/test-pass.js`, '\'use strict\'\n\nmodule.exports = {}\n')
       })
-      .then(() => lint({ silent: true, files: [`${dir}/*.js`] }))
+      .then(() => lint({
+        fix: false,
+        silent: true,
+        files: [`${dir}/*.js`]
+      }))
   })
 
   it('should fail in user defined path globs', async () => {
@@ -179,6 +85,7 @@ describe('lint', () => {
     fs.writeFileSync(`${dir}/test-fail.js`, '() .> {')
 
     await expect(lint({
+      fix: false,
       silent: true,
       files: [`${dir}/*.js`]
     }))

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,44 +1,11 @@
 /* eslint-env mocha */
 'use strict'
 
-const sinon = require('sinon')
-const path = require('path')
 const { expect } = require('../utils/chai')
 
 const utils = require('../src/utils')
 
 describe('utils', () => {
-  it('getBasePath', () => {
-    expect(utils.getBasePath()).to.eql(process.cwd())
-  })
-
-  it('getPathToPkg', () => {
-    sinon.stub(process, 'cwd').returns('hello')
-
-    expect(utils.getPathToPkg()).to.eql(path.normalize('hello/package.json'))
-    process.cwd.restore()
-  })
-
-  it('getPathToDist', () => {
-    expect(utils.getPathToDist()).to.match(/dist$/)
-  })
-
-  it('getLibraryName', () => {
-    const cases = [
-      ['hello world', 'HelloWorld'],
-      ['peer-id', 'PeerId'],
-      ['Peer ID', 'PeerID'],
-      ['aegir', 'Aegir']
-    ]
-    cases.forEach((c) => {
-      expect(utils.getLibraryName(c[0])).to.eql(c[1])
-    })
-  })
-
-  it('getPathToNodeModules', () => {
-    expect(utils.getPathToNodeModules()).to.match(/node_modules$/)
-  })
-
   it('hook', () => {
     const res = utils.hook('node', 'pre')({
       hooks: {


### PR DESCRIPTION
Changes:

599252f (Hugo Dias, 7 minutes ago)
   fix: add types for cmd options

923584d (Hugo Dias, 8 minutes ago)
   feat: clean lint cmd

   - remove old npm deps semver version checks
   - update to the new eslint api
   - use a new output formatter that actually gives us links we can click and
   go to the errors

   BREAKING CHANGE: old npm deps semver was removed

7a68ad1 (Hugo Dias, 10 minutes ago)
   feat: big utils clean up

   - remove unnecessary methods
   - add some types
   - improve `paths` export, with full paths to dist, test, src and
   package.json folder/file

0a4cfc1 (Hugo Dias, 13 minutes ago)
   fix: improve docs cmd

   - add more types
   - clean code and improve Listr setup

c6211a7 (Hugo Dias, 14 minutes ago)
   feat: improve build cmd

   - remove old bundlesize config, add new options for max bundlesize
   `bundlesizeMax`
   - add more types
   - add `bundlesizeMax` default value

   BREAKING CHANGE: Config property `bundlesize.maxSize` is deprecated, use
   `build.bundlesizeMax`

b367858 (Hugo Dias, 18 minutes ago)
   fix: improve ts cmd config

   - get defaults from user config
   - fix noEmit for js repos
   - add more types