### PR TITLE
fix: add tsconfig.aegir.json to typesVersions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
       ],
       "src/": [
         "dist/src/index"
+      ],
+      "src/config/tsconfig.aegir.json": [
+        "src/config/tsconfig.aegir.json"
       ]
     }
   },


### PR DESCRIPTION
Otherwise resolution of the shared config fails during tsc compilation
without an explicit path to the file in your `node_modules` folder which
means the workflow of using gitpkg.now.sh to depend on monorepo packages
in PRs is completely broken if they have a prepare step or any other use
of typescript.

This is one solution, another would be to copy tsconfig.aegir.json to
the `dist` folder during a build, I have no opinion on which is better.

Refs: https://github.com/microsoft/TypeScript/issues/43245