### PR TITLE
feat: add additional chai libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "camelcase": "^6.2.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
+    "chai-bytes": "^0.1.2",
+    "chai-string": "^1.5.0",
     "chai-subset": "^1.6.0",
     "conventional-changelog": "^3.1.24",
     "conventional-github-releaser": "^3.1.5",
@@ -119,6 +121,7 @@
   },
   "devDependencies": {
     "@types/bytes": "^3.1.0",
+    "@types/chai-string": "^1.4.2",
     "@types/conventional-changelog": "^3.1.0",
     "@types/cors": "^2.8.10",
     "@types/eslint": "^7.2.8",

--- a/utils/chai.js
+++ b/utils/chai.js
@@ -6,6 +6,8 @@ const chai = require('chai')
 chai.use(require('chai-as-promised'))
 chai.use(require('dirty-chai'))
 chai.use(require('chai-subset'))
+chai.use(require('chai-bytes'))
+chai.use(require('chai-string'))
 
 const expect = chai.expect
 const assert = chai.assert


### PR DESCRIPTION
These are used by js-ipns so include them in order for it to just use
aegir for it's tests and not have extra chai modules hanging around.