### PR TITLE
fix: export types for chai extensions

### DIFF
--- a/utils/chai.js
+++ b/utils/chai.js
@@ -1,13 +1,18 @@
 'use strict'
 
 const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const chaiParentheses = require('chai-parentheses')
+const chaiSubset = require('chai-subset')
+const chaiBytes = require('chai-bytes')
+const chaiString = require('chai-string')
 
 // Do not reorder these statements - https://github.com/chaijs/chai/issues/1298
-chai.use(require('chai-as-promised'))
-chai.use(require('chai-parentheses'))
-chai.use(require('chai-subset'))
-chai.use(require('chai-bytes'))
-chai.use(require('chai-string'))
+chai.use(chaiAsPromised)
+chai.use(chaiParentheses)
+chai.use(chaiSubset)
+chai.use(chaiBytes)
+chai.use(chaiString)
 
 const expect = chai.expect
 const assert = chai.assert
@@ -15,5 +20,18 @@ const assert = chai.assert
 module.exports = {
   expect,
   assert,
-  chai
+  chai,
+
+  // this is to ensure that we import the chai types in the generated .d.ts file
+  _: {
+    chaiAsPromised,
+    chaiParentheses,
+    chaiSubset,
+    chaiBytes,
+    chaiString
+  }
 }
+
+// we don't actually want to export these things so remove the property
+// @ts-ignore - the operand should be optional
+delete module.exports._


### PR DESCRIPTION
If a chai extension has types they cannot be resolved by modules that depend
on aegir unless those types are in a definitely-typed-style `@types/chai-foo`
module.

This seems to be because we don't export them from the `utils/chai.js`
file so they are not referenced from anywhere, then when we try to use
chai with the extensions from another module their types have not been
loaded so chai's base types are not extended and we have missing methods
everywhere. Unless of course, they are in a `@types/...` module in which case
typescript's default module resolution algorithm will find them, though more
by accident than by design.

Here we export the chai extensions, ensuring their types will be loaded
by the generated `.d.ts` file, then delete the exported property as we don't
really want to export the extensions.