### PR TITLE
chore: move chai-string to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@polka/send-type": "^0.5.2",
     "@types/chai": "^4.2.16",
     "@types/chai-as-promised": "^7.1.3",
+    "@types/chai-string": "^1.4.2",
     "@types/chai-subset": "^1.3.3",
     "@types/mocha": "^8.2.2",
     "@types/node": "^15.6.0",
@@ -121,7 +122,6 @@
   },
   "devDependencies": {
     "@types/bytes": "^3.1.0",
-    "@types/chai-string": "^1.4.2",
     "@types/conventional-changelog": "^3.1.0",
     "@types/cors": "^2.8.10",
     "@types/eslint": "^7.2.8",


### PR DESCRIPTION
It's a runtime dep of dependant modules so needs to be in the dependencies field.