### PR TITLE
feat: enable lib check

### DIFF
--- a/src/config/tsconfig.aegir.json
+++ b/src/config/tsconfig.aegir.json
@@ -27,7 +27,7 @@
         // advanced
         "importsNotUsedAsValues": "error",
         "forceConsistentCasingInFileNames": true,
-        "skipLibCheck": true,
+        "skipLibCheck": false,
         "stripInternal": true,
         "resolveJsonModule": true
     },


### PR DESCRIPTION
Setting `skipLibCheck` to `false` in tsconfig.json means we don't typecheck our own `.d.ts` files which means they are full of errors that only become apparent when someone else builds their project that depends on our modules.

Set `skipLibCheck` to `true` to catch these errors.

BREAKING CHANGE: This will probably surface previously unknown errors