### PR TITLE
add bundleFormat arg to build command to support ESM

### DIFF
--- a/src/build/index.js
+++ b/src/build/index.js
@@ -27,19 +27,26 @@ const merge = require('merge-options').bind({
 const build = async (argv) => {
   const outfile = path.join(paths.dist, 'index.min.js')
   const globalName = pascalcase(pkg.name)
-  const umdPre = `(function (root, factory) {(typeof module === 'object' && module.exports) ? module.exports = factory() : root.${globalName} = factory()}(typeof self !== 'undefined' ? self : this, function () {`
-  const umdPost = `return ${globalName}}));`
+
+  let banner = {}
+  let footer = {}
+  if (argv.bundleFormat === 'iife') {
+    const umdPre = `(function (root, factory) {(typeof module === 'object' && module.exports) ? module.exports = factory() : root.${globalName} = factory()}(typeof self !== 'undefined' ? self : this, function () {`
+    const umdPost = `return ${globalName}}));`
+    banner = { js: umdPre }
+    footer = { js: umdPost }
+  }
   const result = await esbuild.build(merge(
     {
       entryPoints: [fromRoot('src', argv.tsRepo ? 'index.ts' : 'index.js')],
       bundle: true,
-      format: 'iife',
+      format: argv.bundleFormat,
       conditions: ['production'],
       sourcemap: argv.bundlesize,
       minify: true,
       globalName,
-      banner: { js: umdPre },
-      footer: { js: umdPost },
+      banner,
+      footer,
       metafile: argv.bundlesize,
       outfile,
       define: {

--- a/src/cmds/build.js
+++ b/src/cmds/build.js
@@ -37,6 +37,12 @@ module.exports = {
           type: 'boolean',
           describe: 'Build the Typescripts type declarations.',
           default: userConfig.build.types
+        },
+        bundleFormat: {
+          alias: 'f',
+          type: 'string',
+          describe: 'Bundle output format. Possible values: iife, cjs, esm. Default: iife.',
+          default: userConfig.build.bundleFormat
         }
       })
   },

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -39,6 +39,7 @@ const defaults = {
     bundle: true,
     bundlesize: false,
     bundlesizeMax: '100kB',
+    bundleFormat: 'iife',
     types: true,
     config: {}
   },

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -113,6 +113,10 @@ interface BuildOptions {
    */
   bundlesizeMax: string
   /**
+   * Output format for JS bundle. Possible values: `iife`, `cjs`, `esm`. Default: `iife`.
+   */
+  bundleFormat: string
+  /**
    * Build the Typescript type declarations.
    */
   types: boolean


### PR DESCRIPTION
This is a start on adding support for the ESM module output format, to close #673. It adds a `bundleFormat` or `-f` cli argument to the `build` command that gets passed on to esbuild's [format](https://esbuild.github.io/api/#format) option.

I haven't added any tests yet - I couldn't find existing tests for the build command. It seems to pass a basic sanity check if you run it on the aegir repo itself... `node cli.js build -f esm` spits out a `dist/index.min.js` that looks like an ESM module, anyway.

@Gozala do you know of an aegir-based project that we could test this out on easily to see if it works in practice?