### PR TITLE
feat: build esm modules using ipjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 package-lock.json
 yarn.lock
-node_modules
+/node_modules
+/actions/bundle-size/node_modules
 /coverage
 /dist
 /docs

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "git-authors-cli": "^1.0.33",
     "globby": "^11.0.3",
     "ipfs-utils": "^8.1.0",
+    "ipjs": "^5.0.2",
     "it-glob": "~0.0.10",
     "kleur": "^4.1.4",
     "lilconfig": "^2.0.2",
@@ -144,7 +145,10 @@
     "npm": ">=6.0.0"
   },
   "eslintConfig": {
-    "extends": "ipfs"
+    "extends": "ipfs",
+    "ignorePatterns": [
+      "test/fixtures/esm/*"
+    ]
   },
   "contributors": [
     "dignifiedquire <dignifiedquire@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -145,10 +145,7 @@
     "npm": ">=6.0.0"
   },
   "eslintConfig": {
-    "extends": "ipfs",
-    "ignorePatterns": [
-      "test/fixtures/esm/*"
-    ]
+    "extends": "ipfs"
   },
   "contributors": [
     "dignifiedquire <dignifiedquire@gmail.com>",

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -56,10 +56,45 @@ const build = async (argv) => {
   return outfile
 }
 
+/**
+ * Build command
+ *
+ * @param {GlobalOptions & BuildOptions} argv
+ */
+const buildEsm = async (argv) => {
+  const dist = path.join(process.cwd(), 'dist')
+  // @ts-ignore no types
+  const ipjs = await import('ipjs')
+
+  await ipjs.default({
+    dist,
+    onConsole: (/** @type {any[]} */...args) => console.info.apply(console, args),
+    cwd: process.cwd(),
+    main: argv.esmMain,
+    tests: argv.esmTests
+  })
+}
+
 const tasks = new Listr([
   {
     title: 'Clean ./dist',
     task: async () => del(path.join(process.cwd(), 'dist'))
+  },
+  {
+    title: 'Build ESM',
+    enabled: async ctx => {
+      const pkg = await fs.readJSON(path.join(process.cwd(), 'package.json'))
+
+      return pkg.type === 'module'
+    },
+    /**
+     *
+     * @param {GlobalOptions & BuildOptions} ctx
+     * @param {Task} task
+     */
+    task: async (ctx, task) => {
+      await buildEsm(ctx)
+    }
   },
   {
     title: 'Bundle',

--- a/src/cmds/build.js
+++ b/src/cmds/build.js
@@ -37,6 +37,18 @@ module.exports = {
           type: 'boolean',
           describe: 'Build the Typescripts type declarations.',
           default: userConfig.build.types
+        },
+        esmMain: {
+          alias: 'esm-main',
+          type: 'boolean',
+          describe: 'Include a main field in a built esm project',
+          default: userConfig.build.esmMain
+        },
+        esmTests: {
+          alias: 'esm-tests',
+          type: 'boolean',
+          describe: 'Include tests in a built esm project',
+          default: userConfig.build.esmTests
         }
       })
   },

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -40,7 +40,9 @@ const defaults = {
     bundlesize: false,
     bundlesizeMax: '100kB',
     types: true,
-    config: {}
+    config: {},
+    esmMain: true,
+    esmTests: false
   },
   // linter cmd options
   lint: {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -99,6 +99,13 @@ interface GlobalOptions {
   fileConfig: Options
 }
 
+interface ESMHooks {
+  onParse: () => {}
+  onParsed: () => {}
+  onDeflateStart: () => {}
+  onDeflateEnd: () => {}
+}
+
 interface BuildOptions {
   /**
    * Build the JS standalone bundle.
@@ -120,6 +127,14 @@ interface BuildOptions {
    * esbuild build options
    */
   config: esbuild.BuildOptions
+  /**
+   * Include tests in the ipjs output directory
+   */
+  esmTests: boolean
+  /**
+   * Include a main field in the ipjs output package.json
+   */
+  esmMain: boolean
 }
 
 interface TSOptions {

--- a/test/build.js
+++ b/test/build.js
@@ -15,7 +15,7 @@ describe('build', () => {
     before(async () => {
       projectDir = tempy.directory()
 
-      await copy(join(__dirname, 'fixtures/esm/an-esm-project'), projectDir)
+      await copy(join(__dirname, 'fixtures', 'esm', 'an-esm-project'), projectDir)
     })
 
     it('should build an esm project', async function () {
@@ -25,8 +25,8 @@ describe('build', () => {
         cwd: projectDir
       })
 
-      expect(existsSync(join(projectDir, 'dist/esm'))).to.be.true()
-      expect(existsSync(join(projectDir, 'dist/cjs'))).to.be.true()
+      expect(existsSync(join(projectDir, 'dist', 'esm'))).to.be.true()
+      expect(existsSync(join(projectDir, 'dist', 'cjs'))).to.be.true()
 
       const module = require(join(projectDir, 'dist'))
 

--- a/test/build.js
+++ b/test/build.js
@@ -1,0 +1,37 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('../utils/chai')
+const execa = require('execa')
+const { copy, existsSync } = require('fs-extra')
+const { join } = require('path')
+const bin = require.resolve('../')
+const tempy = require('tempy')
+
+describe('build', () => {
+  describe('esm', () => {
+    let projectDir = ''
+
+    before(async () => {
+      projectDir = tempy.directory()
+
+      await copy(join(__dirname, 'fixtures/esm/an-esm-project'), projectDir)
+    })
+
+    it('should build an esm project', async function () {
+      this.timeout(20 * 1000) // slow ci is slow
+
+      await execa(bin, ['build'], {
+        cwd: projectDir
+      })
+
+      expect(existsSync(join(projectDir, 'dist/esm'))).to.be.true()
+      expect(existsSync(join(projectDir, 'dist/cjs'))).to.be.true()
+
+      const module = require(join(projectDir, 'dist'))
+
+      expect(module).to.have.property('useHerp').that.is.a('function')
+      expect(module).to.have.property('useDerp').that.is.a('function')
+    })
+  })
+})

--- a/test/fixtures/esm/an-esm-project/node_modules/a-cjs-dep/package.json
+++ b/test/fixtures/esm/an-esm-project/node_modules/a-cjs-dep/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "a-cjs-dep",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "types": "src",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/esm/an-esm-project/node_modules/a-cjs-dep/src/index.d.ts
+++ b/test/fixtures/esm/an-esm-project/node_modules/a-cjs-dep/src/index.d.ts
@@ -1,0 +1,2 @@
+
+export default function herp(): void

--- a/test/fixtures/esm/an-esm-project/node_modules/a-cjs-dep/src/index.js
+++ b/test/fixtures/esm/an-esm-project/node_modules/a-cjs-dep/src/index.js
@@ -1,0 +1,4 @@
+
+module.exports = () => {
+
+}

--- a/test/fixtures/esm/an-esm-project/node_modules/an-esm-dep/package.json
+++ b/test/fixtures/esm/an-esm-project/node_modules/an-esm-dep/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "an-esm-dep",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "types": "src",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "require": "./src/index.cjs"
+    }
+  }
+}

--- a/test/fixtures/esm/an-esm-project/node_modules/an-esm-dep/src/index.cjs
+++ b/test/fixtures/esm/an-esm-project/node_modules/an-esm-dep/src/index.cjs
@@ -1,0 +1,4 @@
+
+module.exports = () => {
+
+}

--- a/test/fixtures/esm/an-esm-project/node_modules/an-esm-dep/src/index.d.ts
+++ b/test/fixtures/esm/an-esm-project/node_modules/an-esm-dep/src/index.d.ts
@@ -1,0 +1,2 @@
+
+export default function derp(): void

--- a/test/fixtures/esm/an-esm-project/node_modules/an-esm-dep/src/index.js
+++ b/test/fixtures/esm/an-esm-project/node_modules/an-esm-dep/src/index.js
@@ -1,0 +1,4 @@
+
+export default () => {
+
+}

--- a/test/fixtures/esm/an-esm-project/package.json
+++ b/test/fixtures/esm/an-esm-project/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "an-esm-project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/esm/an-esm-project/package.json
+++ b/test/fixtures/esm/an-esm-project/package.json
@@ -8,5 +8,11 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "eslintConfig": {
+    "extends": "ipfs",
+    "parserOptions": {
+      "sourceType": "module"
+    }
+  }
 }

--- a/test/fixtures/esm/an-esm-project/src/index.js
+++ b/test/fixtures/esm/an-esm-project/src/index.js
@@ -1,0 +1,10 @@
+import herp from 'a-cjs-dep'
+import derp from 'an-esm-dep'
+
+export const useHerp = () => {
+  herp()
+}
+
+export const useDerp = () => {
+  derp()
+}

--- a/test/node.js
+++ b/test/node.js
@@ -1,5 +1,6 @@
 'use strict'
 
+require('./build')
 require('./lint')
 require('./fixtures')
 require('./dependants')


### PR DESCRIPTION
Includes ipjs to build esm projects.

- Auto-detects esm projects based on the `"type": "module"` field in the project `package.json`
- Builds cjs and esm version of the project with exports/browser/filesystem fallback for maximum compatibility

TODO:

- [ ] Publishing from `dist` folder
- [ ] Bundling?
- [ ] TS definitions?