### PR TITLE
fix: replace type: 'array' with array: true

### DIFF
--- a/src/cmds/lint.js
+++ b/src/cmds/lint.js
@@ -28,7 +28,7 @@ module.exports = {
           default: userConfig.lint.fix
         },
         files: {
-          type: 'array',
+          array: true,
           describe: 'Files to lint.',
           default: userConfig.lint.files
         },

--- a/src/cmds/test.js
+++ b/src/cmds/test.js
@@ -42,7 +42,7 @@ module.exports = {
         target: {
           alias: 't',
           describe: 'In which target environment to execute the tests',
-          type: 'array',
+          array: true,
           choices: ['node', 'browser', 'webworker', 'electron-main', 'electron-renderer', 'react-native-android', 'react-native-ios'],
           default: userConfig.test.target
         },
@@ -55,7 +55,7 @@ module.exports = {
         files: {
           alias: 'f',
           describe: 'Custom globs for files to test',
-          type: 'array',
+          array: true,
           default: userConfig.test.files
         },
         timeout: {

--- a/src/cmds/ts.js
+++ b/src/cmds/ts.js
@@ -7,11 +7,11 @@ const { userConfig } = require('../config/user')
 
 const EPILOG = `
 Presets:
-\`check\`       Runs the type checker with your local config (without writing any files). . 
+\`check\`       Runs the type checker with your local config (without writing any files). .
 \`types\`       Emits type declarations, copies a any .d.ts files or a types folder to \`dist\` folder.
 \`config\`      Prints base config to stdout.
 
-Note: 
+Note:
 Check out the documentation for JSDoc based TS types here: https://github.com/ipfs/aegir/blob/master/md/ts-jsdoc.md
 
 Supports options forwarding with '--' for more info check https://www.typescriptlang.org/docs/handbook/compiler-options.html
@@ -35,7 +35,7 @@ module.exports = {
           default: userConfig.ts.preset
         },
         include: {
-          type: 'array',
+          array: true,
           describe: 'Values are merged into the local TS config include property.',
           default: userConfig.ts.include
         },

--- a/src/cmds/z-dependency-check.js
+++ b/src/cmds/z-dependency-check.js
@@ -25,8 +25,8 @@ module.exports = {
       .example('aegir dependency-check -- --unused --ignore typescript', 'To check unused packages in your repo, ignoring typescript.')
       .positional('input', {
         describe: 'Files to check',
-        // @ts-ignore
-        type: 'array',
+        type: 'string',
+        array: true,
         default: userConfig.dependencyCheck.input
       })
       .option('p', {
@@ -38,7 +38,7 @@ module.exports = {
       .option('i', {
         alias: 'ignore',
         describe: 'Ignore these dependencies when considering which are used and which are not',
-        type: 'array',
+        array: true,
         default: userConfig.dependencyCheck.ignore
       })
   },


### PR DESCRIPTION
`'array'` is not a valid value for `'type'` so we can remove the `@ts-ignore` that was smothering the error message telling us so.