### PR TITLE
chore: copy bundle-size to root

### DIFF
--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -2,4 +2,5 @@
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
 ADD dist bundle_size_dist
-CMD [ "node", "bundle_size_dist/index.js" ]
+#CMD [ "node", "bundle_size_dist/index.js" ]
+CMD [ "ls", "-laR" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -4,4 +4,4 @@ FROM node:16-alpine
 WORKDIR /github/workspace
 ADD dist /github/workspace/bundle_size_dist
 #CMD [ "node", "bundle_size_dist/index.js" ]
-CMD [ "ls", "-la", "/" ]
+CMD [ "find", "/", "-type", "d", "-name", "bundle_size_dist" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -2,6 +2,6 @@
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
 WORKDIR /github/workspace
-COPY dist /github/workspace/bundle_size_dist
+COPY ./dist/index.js /github/workspace/bundle_size.js
 #CMD [ "node", "/github/workspace/bundle_size_dist/index.js" ]
 CMD ["ls", "-la", "/github/workspace"]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -2,6 +2,4 @@
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
 WORKDIR /usr/src/app
-ADD * /usr/src/app
-RUN ls -la
-CMD [ "node", "dist/index.js" ]
+CMD [ "ls", "-la" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -1,5 +1,5 @@
 # Just enough docker until github gets a new node16 runner
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
-COPY ./dist/index.js /bundle_size.js
-CMD [ "node", "/bundle_size.js" ]
+COPY ./dist/index.js /bundle-size.js
+CMD [ "node", "/bundle-size.js" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -4,4 +4,4 @@ FROM node:16-alpine
 WORKDIR /github/workspace
 ADD dist /github/workspace/bundle_size_dist
 #CMD [ "node", "bundle_size_dist/index.js" ]
-CMD [ "ls", "-la" ]
+CMD [ "ls", "-la", "/" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -2,4 +2,5 @@
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
 WORKDIR /usr/src/app
+RUN ls -la
 CMD [ "node", "dist/index.js" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -1,4 +1,5 @@
 # Just enough docker until github gets a new node16 runner
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
-CMD [ "node", "node_modules/aegir/actions/bundle-size/dist/index.js" ]
+#CMD [ "node", "node_modules/aegir/actions/bundle-size/dist/index.js" ]
+CMD [ "ls", "node_modules/aegir" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -3,4 +3,5 @@
 FROM node:16-alpine
 WORKDIR /github/workspace
 COPY dist /github/workspace/bundle_size_dist
-CMD [ "node", "bundle_size_dist/index.js" ]
+#CMD [ "node", "/github/workspace/bundle_size_dist/index.js" ]
+CMD ["ls", "-la", "/github/workspace"]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -1,6 +1,6 @@
 # Just enough docker until github gets a new node16 runner
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
-WORKDIR /usr/src/app
+WORKDIR /github/workspace
 RUN ls -la
 CMD [ "node", "dist/index.js" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -3,5 +3,4 @@
 FROM node:16-alpine
 WORKDIR /github/workspace
 COPY ./dist/index.js /bundle_size.js
-RUN ls -la /
 CMD [ "node", "/bundle_size.js" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -2,6 +2,6 @@
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
 WORKDIR /github/workspace
-ADD dist bundle_size_dist
+ADD dist /github/workspace/bundle_size_dist
 #CMD [ "node", "bundle_size_dist/index.js" ]
 CMD [ "ls", "-la" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -1,5 +1,4 @@
 # Just enough docker until github gets a new node16 runner
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
-WORKDIR /usr/src/app
-CMD [ "ls", "-la" ]
+CMD [ "node", "node_modules/aegir/actions/bundle-size/dist/index.js" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -1,6 +1,7 @@
 # Just enough docker until github gets a new node16 runner
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
-WORKDIR /github/workspace
+WORKDIR /usr/src/app
+ADD * /usr/src/app
 RUN ls -la
 CMD [ "node", "dist/index.js" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -1,6 +1,5 @@
 # Just enough docker until github gets a new node16 runner
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
-WORKDIR /github/workspace
 COPY ./dist/index.js /bundle_size.js
 CMD [ "node", "/bundle_size.js" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -1,6 +1,7 @@
 # Just enough docker until github gets a new node16 runner
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
+WORKDIR /github/workspace
 ADD dist bundle_size_dist
 #CMD [ "node", "bundle_size_dist/index.js" ]
-CMD [ "ls", "-laR" ]
+CMD [ "ls", "-la" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -3,5 +3,5 @@
 FROM node:16-alpine
 WORKDIR /github/workspace
 COPY ./dist/index.js /github/workspace/bundle_size.js
-#CMD [ "node", "/github/workspace/bundle_size_dist/index.js" ]
-CMD ["ls", "-la", "/github/workspace"]
+RUN ls -la /github/workspace
+CMD [ "node", "/github/workspace/bundle_size.js" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -2,6 +2,6 @@
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
 WORKDIR /github/workspace
-COPY ./dist/index.js /github/workspace/bundle_size.js
-RUN ls -la /github/workspace
-CMD [ "node", "/github/workspace/bundle_size.js" ]
+COPY ./dist/index.js /bundle_size.js
+RUN ls -la /
+CMD [ "node", "/bundle_size.js" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -1,5 +1,5 @@
 # Just enough docker until github gets a new node16 runner
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
-#CMD [ "node", "node_modules/aegir/actions/bundle-size/dist/index.js" ]
-CMD [ "ls", "node_modules/aegir" ]
+ADD dist bundle_size_dist
+CMD [ "node", "bundle_size_dist/index.js" ]

--- a/actions/bundle-size/Dockerfile
+++ b/actions/bundle-size/Dockerfile
@@ -2,6 +2,5 @@
 # see: https://github.com/actions/runner/issues/772
 FROM node:16-alpine
 WORKDIR /github/workspace
-ADD dist /github/workspace/bundle_size_dist
-#CMD [ "node", "bundle_size_dist/index.js" ]
-CMD [ "find", "/", "-type", "d", "-name", "bundle_size_dist" ]
+COPY dist /github/workspace/bundle_size_dist
+CMD [ "node", "bundle_size_dist/index.js" ]


### PR DESCRIPTION
Docker actions get their workspace overridden as `/docker/workspace`.  Your project files are copied to that folder \*after* your docker file is run but \*before* the `CMD` directive is executed, so you can't copy anything to that folder and expect it to still be there.

The contents of `/docker/workspace` are the project, not the gh action, so `dist/index.js` does not exist.

We don't ship gh actions with aegir so you can't use `/docker/workspace/node_modules/aegir/actions/bundle-size/dist/index.js` either.

Also, you can't use slashes in branch names for gh actions as they get copied onto the filesystem then the directory structure doesn't match up.

The working directory of the docker image is `/docker/workspace` so we can copy the bundle size index.js to the root and run it from there but check the size of the current project due to the CWD being set to the docker workspace.

This branch is building
 * a CJS module here: https://github.com/multiformats/js-multiaddr/pull/207
 * a ESM module here: https://github.com/achingbrain/uint8arrays/pull/26