### PR TITLE
fix: search for aegir.cjs

### DIFF
--- a/src/config/user.js
+++ b/src/config/user.js
@@ -135,7 +135,8 @@ const config = (searchFrom) => {
 
       searchPlaces: [
         'package.json',
-        '.aegir.js'
+        '.aegir.js',
+        '.aegir.cjs'
       ]
     })
     const lilconfig = configExplorer.search(searchFrom)


### PR DESCRIPTION
In esm projects, sometimes `.aegir.js` is called `.aegir.cjs`