### PR TITLE
fix: exit with an error when testing dependants fails

### DIFF
--- a/src/cmds/test-dependant.js
+++ b/src/cmds/test-dependant.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict'
 
 module.exports = {
@@ -43,8 +44,21 @@ module.exports = {
   /**
    * @param {{ repo: string; branch: string; deps: any; }} argv
    */
-  handler (argv) {
+  async handler (argv) {
     const cmd = require('../test-dependant')
-    return cmd(argv)
+
+    try {
+      await cmd(argv)
+    } catch (/** @type {any} */ err) {
+      console.info('-------------------------------------------------------------------')
+      console.info('')
+      console.info(err.message)
+      console.info('')
+      console.info('Dependant project has not been tested with updated dependencies')
+      console.info('')
+      console.info('-------------------------------------------------------------------')
+
+      throw err
+    }
   }
 }

--- a/test/dependants.js
+++ b/test/dependants.js
@@ -86,6 +86,16 @@ describe('dependants', function () {
       expect(output.stdout).to.include(`${diff}-dependency-version=1.0.0`)
       expect(output.stdout).to.include(`${diff}-dependency-version=1.0.1`)
     })
+
+    it('should fail to test a project that does not depend on the deps we are overridding', async () => {
+      const diff = `derp-${Math.random()}`
+
+      await expect(execa(bin, ['test-dependant', dirs.project, '--deps=it-derp@1.0.1'], {
+        env: {
+          DISAMBIGUATOR: diff
+        }
+      })).to.eventually.be.rejectedWith(/Module project does not depend on it-derp/)
+    })
   })
 
   describe('monorepo', () => {


### PR DESCRIPTION
Print an error message and exit with a non-zero code when testing dependants fails