### PR TITLE
fix: simulate node_modules lookup when loading fixtures

### DIFF
--- a/utils/fixtures.js
+++ b/utils/fixtures.js
@@ -40,6 +40,19 @@ function loadFixtures (filePath, module = '') {
     resolve(filePath)
   ]
 
+  if (module) {
+    // simulate node's node_modules lookup
+    for (let i = 0; i < process.cwd().split(path.sep).length; i++) {
+      const dots = new Array(i).fill('..')
+
+      paths.push(
+        path.resolve(
+          path.join(process.cwd(), ...dots, 'node_modules', filePath)
+        )
+      )
+    }
+  }
+
   const resourcePath = paths.find(path => fs.existsSync(path))
 
   if (!resourcePath) {


### PR DESCRIPTION
We need to be able to load fixture files from modules like `interface-ipfs-core`.

As these modules transition to ESM, they define their export maps but
IPJS needs these to only contain js files so we can't use it for fixtures
though that gets unwieldy quite quickly anyway.

Instead simulate node's node_modules lookup, stepping up the file system
path searching every folder called node_modules if it exists.