### PR TITLE
feat: add resolve command

### DIFF
--- a/utils/fixtures.js
+++ b/utils/fixtures.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const path = require('path')
 const fs = require('fs')
+const resolve = require('./resolve')
 
 /**
  * Loading fixture files in node and the browser can be painful, that's why aegir provides a method to do this.
@@ -30,47 +30,7 @@ const fs = require('fs')
  * @param {string} [module]
  */
 function loadFixtures (filePath, module = '') {
-  if (module) {
-    filePath = path.join(module, filePath)
-  }
-
-  const paths = [
-    path.join(process.cwd(), filePath),
-    path.join(process.cwd(), 'node_modules', filePath),
-    resolve(filePath)
-  ]
-
-  if (module) {
-    // simulate node's node_modules lookup
-    for (let i = 0; i < process.cwd().split(path.sep).length; i++) {
-      const dots = new Array(i).fill('..')
-
-      paths.push(
-        path.resolve(
-          path.join(process.cwd(), ...dots, 'node_modules', filePath)
-        )
-      )
-    }
-  }
-
-  const resourcePath = paths.find(path => fs.existsSync(path))
-
-  if (!resourcePath) {
-    throw new Error(`Could not load ${filePath}`)
-  }
-
-  return fs.readFileSync(resourcePath)
+  return fs.readFileSync(resolve(filePath, module))
 }
 
-/**
- * @param {string} filePath
- */
-function resolve (filePath) {
-  try {
-    return require.resolve(filePath)
-  } catch (error) {
-    // ignore error
-    return filePath
-  }
-}
 module.exports = loadFixtures

--- a/utils/resolve.js
+++ b/utils/resolve.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+
+/**
+ * Returns the full path to the requested resource, if available
+ *
+ * @param {string} filePath
+ * @param {string} [module]
+ */
+function resolve (filePath, module = '') {
+  if (module) {
+    filePath = path.join(module, filePath)
+  }
+
+  const paths = [
+    path.join(process.cwd(), filePath),
+    path.join(process.cwd(), 'node_modules', filePath),
+    requireResolve(filePath)
+  ]
+
+  if (module) {
+    // simulate node's node_modules lookup
+    for (let i = 0; i < process.cwd().split(path.sep).length; i++) {
+      const dots = new Array(i).fill('..')
+
+      paths.push(
+        path.resolve(
+          path.join(process.cwd(), ...dots, 'node_modules', filePath)
+        )
+      )
+    }
+  }
+
+  const resourcePath = paths.find(path => fs.existsSync(path))
+
+  if (!resourcePath) {
+    throw new Error(`Could not load ${filePath}`)
+  }
+
+  return resourcePath
+}
+
+/**
+ * @param {string} filePath
+ */
+function requireResolve (filePath) {
+  try {
+    return require.resolve(filePath)
+  } catch (error) {
+    // ignore error
+    return filePath
+  }
+}
+
+module.exports = resolve


### PR DESCRIPTION
The ESM `import.meta.url` value does not work reliably in environments
like electron just yet so add a resolve command to let us work out
paths to files in dependencies.