### PR TITLE
feat: support source maps for ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "read-pkg-up": "7.0.1",
     "semver": "^7.3.5",
     "simple-git": "^2.37.0",
+    "source-map-support": "^0.5.20",
     "strip-bom": "4.0.0",
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.1",

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -40,6 +40,7 @@ async function testNode (argv, execaOptions) {
     ...files,
     ...progress,
     '--ui', 'bdd',
+    '--require', 'source-map-support/register',
     `--timeout=${argv.timeout}`
   ]
 


### PR DESCRIPTION
If your tests are written in ts, you need to include `source-map-support` in order to get stack traces that point to the ts code, otherwise they point to the transpiled code which is a pain to deal with.

Also fixes the recent breakage with dep checking - looks like they stopped bundling the `detective` module, so I've switched it for `detective-cjs` since that's what's now used in the dependency-check module tests.