### PR TITLE
fix: doc generation

### DIFF
--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -6,10 +6,12 @@ const execa = require('execa')
 const fs = require('fs-extra')
 const path = require('path')
 const { premove: del } = require('premove/sync')
+const merge = require('merge-options')
 const {
   hasTsconfig,
   fromAegir,
-  fromRoot
+  fromRoot,
+  readJson
 } = require('../utils')
 const ghPages = require('gh-pages')
 const { promisify } = require('util')
@@ -33,40 +35,73 @@ const publishPages = promisify(ghPages.publish)
  * @param {Task} task
  */
 const docs = async (ctx, task) => {
-  /** @type {Options} */
-  const opts = {
-    forwardOptions: ctx['--'] ? ctx['--'] : [],
-    entryPoint: ctx.entryPoint
-  }
-  if (!hasTsconfig) {
-    // eslint-disable-next-line no-console
-    console.error(kleur.yellow('Documentation requires typescript config.\nTry running `aegir ts --preset config > tsconfig.json`'))
-    return
-  }
-  // run typedoc
-  const proc = execa(
-    'typedoc',
-    [
-      fromRoot(opts.entryPoint),
-      '--out', 'docs',
-      '--hideGenerator',
-      '--includeVersion',
-      '--gitRevision', 'master',
-      '--plugin', fromAegir('src/ts/typedoc-plugin.js'),
-      ...opts.forwardOptions
-    ],
-    {
-      localDir: path.join(__dirname, '..'),
-      preferLocal: true
-    }
-  )
-  proc.all?.on('data', chunk => {
-    task.output = chunk.toString().replace('\n', '')
-  })
-  await proc
+  let userTSConfig = readJson(fromRoot('tsconfig.json'))
+  const configPath = fromRoot('tsconfig-docs.aegir.json')
 
-  // write .nojekyll file
-  fs.writeFileSync('docs/.nojekyll', '')
+  try {
+    if (userTSConfig.extends) {
+      const extendedConf = readJson(require.resolve(userTSConfig.extends))
+
+      userTSConfig = merge.apply({ concatArrays: true }, [
+        extendedConf,
+        userTSConfig
+      ])
+
+      delete userTSConfig.extends
+    }
+
+    const config = {
+      ...userTSConfig
+    }
+
+    if (config.compilerOptions) {
+      // remove config options that cause tsdoc to fail
+      delete config.compilerOptions.emitDeclarationOnly
+    }
+
+    fs.writeJsonSync(
+      configPath,
+      config
+    )
+
+    /** @type {Options} */
+    const opts = {
+      forwardOptions: ctx['--'] ? ctx['--'] : [],
+      entryPoint: ctx.entryPoint
+    }
+    if (!hasTsconfig) {
+    // eslint-disable-next-line no-console
+      console.error(kleur.yellow('Documentation requires typescript config.\nTry running `aegir ts --preset config > tsconfig.json`'))
+      return
+    }
+    // run typedoc
+    const proc = execa(
+      'typedoc',
+      [
+        fromRoot(opts.entryPoint),
+        '--tsconfig', configPath,
+        '--out', 'docs',
+        '--hideGenerator',
+        '--includeVersion',
+        '--gitRevision', 'master',
+        '--plugin', fromAegir('src/ts/typedoc-plugin.js'),
+        ...opts.forwardOptions
+      ],
+      {
+        localDir: path.join(__dirname, '..'),
+        preferLocal: true
+      }
+    )
+    proc.all?.on('data', chunk => {
+      task.output = chunk.toString().replace('\n', '')
+    })
+    await proc
+
+    // write .nojekyll file
+    fs.writeFileSync('docs/.nojekyll', '')
+  } finally {
+    fs.removeSync(configPath)
+  }
 }
 
 const publishDocs = () => {


### PR DESCRIPTION
There's a conflict between the `noEmit` and `emitDeclarationOnly` config
directives that causes typedoc to bail.

Read the users' config and remove the conflict before generating docs.

Fixes #881