### PR TITLE
chore: remove chai-checkmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "chai-bytes": "^0.1.2",
-    "chai-checkmark": "^1.0.1",
     "chai-parentheses": "^0.0.2",
     "chai-string": "^1.5.0",
     "chai-subset": "^1.6.0",

--- a/utils/chai.js
+++ b/utils/chai.js
@@ -6,8 +6,6 @@ const chaiParentheses = require('chai-parentheses')
 const chaiSubset = require('chai-subset')
 const chaiBytes = require('chai-bytes')
 const chaiString = require('chai-string')
-// @ts-expect-error no types
-const chaiCheckmark = require('chai-checkmark')
 
 // Do not reorder these statements - https://github.com/chaijs/chai/issues/1298
 chai.use(chaiAsPromised)
@@ -15,7 +13,6 @@ chai.use(chaiParentheses)
 chai.use(chaiSubset)
 chai.use(chaiBytes)
 chai.use(chaiString)
-chai.use(chaiCheckmark)
 
 const expect = chai.expect
 const assert = chai.assert
@@ -31,8 +28,7 @@ module.exports = {
     chaiParentheses,
     chaiSubset,
     chaiBytes,
-    chaiString,
-    chaiCheckmark
+    chaiString
   }
 }
 


### PR DESCRIPTION
Chai-checkmark doesn't work well with promise based flow control as it requires a `done` function and mocha objects to the use of both `done` and `async` in test function signatures.

Probably better to just use await instead.  As a bonus it also makes the logic in a test easier to follow.