### PR TITLE
chore: demand up to date ipjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "git-authors-cli": "^1.0.33",
     "globby": "^11.0.3",
     "ipfs-utils": "^9.0.1",
-    "ipjs": "^5.0.5",
+    "ipjs": "^5.1.2",
     "it-glob": "^1.0.1",
     "kleur": "^4.1.4",
     "lilconfig": "^2.0.2",


### PR DESCRIPTION
To fix bugs like https://github.com/ipfs/js-ipfs/issues/3938 where Jest ends up resolving browser specific code, use a version of ipjs with the fix.