### PR TITLE
chore: swap chai-bytes for chai-bites

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "camelcase": "^6.2.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
-    "chai-bytes": "^0.1.2",
+    "chai-bites": "^0.1.2",
     "chai-parentheses": "^0.0.2",
     "chai-string": "^1.5.0",
     "chai-subset": "^1.6.0",

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,7 @@ describe('test', () => {
     })
 
     it('should test an esm project', async function () {
-      this.timeout(20 * 1000) // slow ci is slow
+      this.timeout(60 * 1000) // slow ci is slow
 
       await execa(bin, ['test'], {
         cwd: projectDir

--- a/utils/chai.js
+++ b/utils/chai.js
@@ -4,14 +4,14 @@ const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const chaiParentheses = require('chai-parentheses')
 const chaiSubset = require('chai-subset')
-const chaiBytes = require('chai-bytes')
+const chaiBites = require('chai-bites')
 const chaiString = require('chai-string')
 
 // Do not reorder these statements - https://github.com/chaijs/chai/issues/1298
 chai.use(chaiAsPromised)
 chai.use(chaiParentheses)
 chai.use(chaiSubset)
-chai.use(chaiBytes)
+chai.use(chaiBites)
 chai.use(chaiString)
 
 const expect = chai.expect
@@ -27,7 +27,7 @@ module.exports = {
     chaiAsPromised,
     chaiParentheses,
     chaiSubset,
-    chaiBytes,
+    chaiBites,
     chaiString
   }
 }


### PR DESCRIPTION
Swaps `chai-bytes` for `chai-bites` as we can write tests that are less verbose.