### PR TITLE
fix: tsc receives forward args

### DIFF
--- a/src/build/index.js
+++ b/src/build/index.js
@@ -130,9 +130,7 @@ const tasks = new Listr([
      */
     task: async (ctx, task) => {
       await tsCmd({
-        debug: ctx.debug,
-        tsRepo: ctx.tsRepo,
-        fileConfig: ctx.fileConfig,
+        ...ctx,
         preset: 'types',
         include: ctx.fileConfig.ts.include,
         copyTo: ctx.fileConfig.ts.copyTo,


### PR DESCRIPTION
forward args are now being passed to `tsCmd` via the `ctx` object in the 'Generate types' task

fixes #940