### PR TITLE
fix: exclude .ts files from electron test

### DIFF
--- a/src/test/electron.js
+++ b/src/test/electron.js
@@ -23,7 +23,7 @@ export default async (argv, execaOptions) => {
   const files = argv.files.length > 0
     ? [...argv.files]
     : [
-        'test/**/*.spec.{js,ts,mjs,cjs}',
+        'test/**/*.spec.{js,mjs,cjs}',
         'dist/test/**/*.spec.{js,cjs,mjs}'
       ]
   const grep = argv.grep ? ['--grep', argv.grep] : []


### PR DESCRIPTION
Run tests using compiled code instead