### PR TITLE
fix: use @semantic-release/github fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/git": "^10.0.1",
-    "@semantic-release/github": "^8.0.2",
+    "@semantic-release/github": "https://registry.npmjs.org/@achingbrain/semantic-release-github/-/semantic-release-github-0.0.0.tgz",
     "@semantic-release/npm": "^9.0.1",
     "@semantic-release/release-notes-generator": "^10.0.3",
     "@types/chai": "^4.2.16",


### PR DESCRIPTION
@semantic-release/github doesn't respect GitHub's rate limiting - it
did once but it looks like GH changed their response type and now it doesn't
which means publishing large monorepos like `@libp2p/interfaces` is a dice
roll as to whether it will succeed or not.

Here we switch to a temporary fork that uses the `@octokit` plugins
for throttling and retrying so it should be more reliable.

Refs: https://github.com/semantic-release/semantic-release/issues/2204