### PR TITLE
fix: run npm scripts instead of chaining to other commands

### DIFF
--- a/src/cmds/release.js
+++ b/src/cmds/release.js
@@ -1,4 +1,3 @@
-import { loadUserConfig } from '../config/user.js'
 import releaseCmd from '../release.js'
 
 /**
@@ -19,33 +18,8 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
-    const userConfig = await loadUserConfig()
-
     return yargs
       .epilog(EPILOG)
-      .options({
-        bundle: {
-          type: 'boolean',
-          describe: 'Build the JS standalone bundle.',
-          default: userConfig.build.bundle
-        },
-        bundlesize: {
-          alias: 'b',
-          type: 'boolean',
-          describe: 'Analyse bundle size.',
-          default: userConfig.build.bundlesize
-        },
-        bundlesizeMax: {
-          type: 'string',
-          describe: 'Max threshold for the bundle size.',
-          default: userConfig.build.bundlesizeMax
-        },
-        types: {
-          type: 'boolean',
-          describe: 'If a tsconfig.json is present in the project, run tsc.',
-          default: userConfig.build.types
-        }
-      })
   },
   /**
    * @param {any} argv

--- a/src/release.js
+++ b/src/release.js
@@ -6,7 +6,6 @@ import { isMonorepoProject } from './utils.js'
 
 /**
  * @typedef {import("./types").GlobalOptions} GlobalOptions
- * @typedef {import("./types").BuildOptions} BuildOptions
  * @typedef {import("listr").ListrTaskWrapper} Task
  */
 
@@ -21,10 +20,7 @@ const tasks = new Listr([
   },
   {
     title: 'build',
-    /**
-     * @param {GlobalOptions & BuildOptions} ctx
-     */
-    task: async (ctx) => {
+    task: async () => {
       await execa('npm', ['run', 'build', '--if-present'], {
         stdio: 'inherit'
       })

--- a/src/release.js
+++ b/src/release.js
@@ -2,8 +2,6 @@
 
 import Listr from 'listr'
 import { execa } from 'execa'
-import cleanCmd from './clean.js'
-import buildCmd from './build/index.js'
 import { isMonorepoProject } from './utils.js'
 
 /**
@@ -15,11 +13,10 @@ import { isMonorepoProject } from './utils.js'
 const tasks = new Listr([
   {
     title: 'clean',
-    /**
-     * @param {GlobalOptions} ctx
-     */
-    task: async (ctx) => {
-      await cleanCmd.run(ctx)
+    task: async () => {
+      await execa('npm', ['run', 'clean', '--if-present'], {
+        stdio: 'inherit'
+      })
     }
   },
   {
@@ -28,7 +25,9 @@ const tasks = new Listr([
      * @param {GlobalOptions & BuildOptions} ctx
      */
     task: async (ctx) => {
-      await buildCmd.run(ctx)
+      await execa('npm', ['run', 'build', '--if-present'], {
+        stdio: 'inherit'
+      })
     }
   },
   {


### PR DESCRIPTION
Some projects have pre/post build npm scripts that need to run to copy files etc.

When performing a release, we clean, build and publish so use the defined npm scripts to do these things instead of chaining to our own commands, this way the other lifecycle scripts are run too.