### PR TITLE
fix: run uncompiled tests for browsers

### DIFF
--- a/src/test/browser.js
+++ b/src/test/browser.js
@@ -30,7 +30,7 @@ export default async (argv, execaOptions) => {
   const files = argv.files.length > 0
     ? argv.files
     : [
-        '**/*.spec.{js,ts,cjs,mjs}',
+        'test/**/*.spec.{js,ts,cjs,mjs}',
         'test/browser.{js,ts,cjs,mjs}'
       ]
 

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -3,8 +3,8 @@ import node from './node.js'
 import browser from './browser.js'
 import electron from './electron.js'
 import rn from './react-native.js'
-import buildCmd from '../build/index.js'
 import { isTypescript } from '../utils.js'
+import { execa } from 'execa'
 
 /**
  * @typedef {import("execa").Options} ExecaOptions
@@ -26,7 +26,9 @@ const TASKS = [
      * @param {BuildOptions & GlobalOptions} ctx
      */
     task: async (ctx) => {
-      await buildCmd.run(ctx)
+      await execa('npm', ['run', 'build', '--if-present'], {
+        stdio: 'inherit'
+      })
     }
   },
   {

--- a/src/test/react-native.js
+++ b/src/test/react-native.js
@@ -29,7 +29,7 @@ export default async (argv, execaOptions) => {
   const files = argv.files.length > 0
     ? argv.files
     : [
-        '**/*.spec.{js,ts,cjs,mjs}',
+        'test/**/*.spec.{js,ts,cjs,mjs}',
         'test/browser.{js,ts,cjs,mjs}'
       ]
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,6 @@ import fs, { copy } from 'fs-extra'
 import path, { join } from 'path'
 import tempy from 'tempy'
 import { fileURLToPath } from 'url'
-import os from 'os'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -28,29 +27,10 @@ async function setUpProject (project) {
     await fs.createSymlink(path.join(nodeModulesPath, entry), path.join(projectDir, 'node_modules', entry), 'dir')
   }
 
-  // symlink aegir
-  await fs.createSymlink(path.resolve(__dirname, '..'), path.join(projectDir, 'node_modules/aegir'), 'dir')
-
-  // simulate aegir linked in node_modules/.bin
-  if (os.platform() === 'win32') {
-    await fs.writeFile(path.join(projectDir, 'node_modules/.bin/aegir.cmd'), `#!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
-
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
-esac
-
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../aegir/src/index" "$@"
-else
-  exec node  "$basedir/../aegir/src/index" "$@"
-fi`)
-    await fs.chmod(path.join(projectDir, 'node_modules/.bin/aegir.cmd'), 0o755)
-  } else {
-    await fs.createSymlink(path.resolve(__dirname, '../src/index.js'), path.join(projectDir, 'node_modules/.bin/aegir'), 'file')
-    await fs.chmod(path.resolve(__dirname, '../src/index.js'), 0o755)
-    await fs.chmod(path.join(projectDir, 'node_modules/.bin/aegir'), 0o755)
-  }
+  // link aegir into project
+  await execa('npm', ['link', path.resolve(__dirname, '..')], {
+    cwd: projectDir
+  })
 
   return projectDir
 }

--- a/test/test.js
+++ b/test/test.js
@@ -36,10 +36,13 @@ async function setUpProject (project) {
   // symlink binary
   await fs.createSymlink(path.resolve(__dirname, '../src/index.js'), path.join(projectDir, 'node_modules/.bin/aegir'), 'file')
 
+  // ensure binary is executable
+  await fs.chmod(path.resolve(__dirname, '../src/index.js'), 0o755)
+
   return projectDir
 }
 
-describe('test', () => {
+describe.only('test', () => {
   describe('esm', function () {
     let projectDir = ''
 

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,9 @@ async function setUpProject (project) {
   // symlink aegir
   await fs.createSymlink(path.resolve(__dirname, '..'), path.join(projectDir, 'node_modules/aegir'), 'dir')
 
+  // ensure binary is executable
+  await fs.chmod(path.resolve(__dirname, '../src/index.js'), 0o755)
+
   return projectDir
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -42,7 +42,7 @@ async function setUpProject (project) {
   return projectDir
 }
 
-describe.only('test', () => {
+describe('test', () => {
   describe('esm', function () {
     let projectDir = ''
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,11 +5,8 @@ import fs, { copy } from 'fs-extra'
 import path, { join } from 'path'
 import tempy from 'tempy'
 import { fileURLToPath } from 'url'
-import { createRequire } from 'module'
 
-const require = createRequire(import.meta.url)
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const bin = require.resolve('../src/index.js')
 
 /**
  * @param {string} project
@@ -47,7 +44,7 @@ describe('test', () => {
     it('should test an esm project', async function () {
       this.timeout(120 * 1000) // slow ci is slow
 
-      await execa('node', [bin, 'test'], {
+      await execa('npm', ['test'], {
         cwd: projectDir
       })
     })
@@ -63,7 +60,7 @@ describe('test', () => {
     it('should test a ts project', async function () {
       this.timeout(120 * 1000) // slow ci is slow
 
-      await execa('node', [bin, 'test'], {
+      await execa('npm', ['test'], {
         cwd: projectDir
       })
     })

--- a/test/test.js
+++ b/test/test.js
@@ -26,10 +26,15 @@ async function setUpProject (project) {
       continue
     }
 
+    // symlink dep
     await fs.createSymlink(path.join(nodeModulesPath, entry), path.join(projectDir, 'node_modules', entry), 'dir')
   }
 
+  // symlink aegir
   await fs.createSymlink(path.resolve(__dirname, '..'), path.join(projectDir, 'node_modules/aegir'), 'dir')
+
+  // symlink binary
+  await fs.createSymlink(path.resolve(__dirname, '../src/index.js'), path.join(projectDir, 'node_modules/.bin/aegir'), 'file')
 
   return projectDir
 }

--- a/test/test.js
+++ b/test/test.js
@@ -31,7 +31,9 @@ async function setUpProject (project) {
   await fs.createSymlink(path.resolve(__dirname, '..'), path.join(projectDir, 'node_modules/aegir'), 'dir')
 
   // ensure binary is executable
+  await fs.createSymlink(path.resolve(__dirname, '../src/index.js'), path.join(projectDir, 'node_modules/.bin/aegir'), 'file')
   await fs.chmod(path.resolve(__dirname, '../src/index.js'), 0o755)
+  await fs.chmod(path.join(projectDir, 'node_modules/.bin/aegir'), 0o755)
 
   return projectDir
 }

--- a/test/test.js
+++ b/test/test.js
@@ -33,12 +33,6 @@ async function setUpProject (project) {
   // symlink aegir
   await fs.createSymlink(path.resolve(__dirname, '..'), path.join(projectDir, 'node_modules/aegir'), 'dir')
 
-  // symlink binary
-  await fs.createSymlink(path.resolve(__dirname, '../src/index.js'), path.join(projectDir, 'node_modules/.bin/aegir'), 'file')
-
-  // ensure binary is executable
-  await fs.chmod(path.resolve(__dirname, '../src/index.js'), 0o755)
-
   return projectDir
 }
 
@@ -53,7 +47,7 @@ describe('test', () => {
     it('should test an esm project', async function () {
       this.timeout(120 * 1000) // slow ci is slow
 
-      await execa(bin, ['test'], {
+      await execa('node', [bin, 'test'], {
         cwd: projectDir
       })
     })
@@ -69,7 +63,7 @@ describe('test', () => {
     it('should test a ts project', async function () {
       this.timeout(120 * 1000) // slow ci is slow
 
-      await execa(bin, ['test'], {
+      await execa('node', [bin, 'test'], {
         cwd: projectDir
       })
     })

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ import fs, { copy } from 'fs-extra'
 import path, { join } from 'path'
 import tempy from 'tempy'
 import { fileURLToPath } from 'url'
+import os from 'os'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -30,10 +31,17 @@ async function setUpProject (project) {
   // symlink aegir
   await fs.createSymlink(path.resolve(__dirname, '..'), path.join(projectDir, 'node_modules/aegir'), 'dir')
 
-  // ensure binary is executable
-  await fs.createSymlink(path.resolve(__dirname, '../src/index.js'), path.join(projectDir, 'node_modules/.bin/aegir'), 'file')
-  await fs.chmod(path.resolve(__dirname, '../src/index.js'), 0o755)
-  await fs.chmod(path.join(projectDir, 'node_modules/.bin/aegir'), 0o755)
+  if (os.platform() === 'win32') {
+    // ensure binary is executable
+    await fs.createSymlink(path.resolve(__dirname, '../src/index.js'), path.join(projectDir, 'node_modules/.bin/aegir.cmd'), 'file')
+    await fs.chmod(path.resolve(__dirname, '../src/index.js'), 0o755)
+    await fs.chmod(path.join(projectDir, 'node_modules/.bin/aegir.cmd'), 0o755)
+  } else {
+    // ensure binary is executable
+    await fs.createSymlink(path.resolve(__dirname, '../src/index.js'), path.join(projectDir, 'node_modules/.bin/aegir'), 'file')
+    await fs.chmod(path.resolve(__dirname, '../src/index.js'), 0o755)
+    await fs.chmod(path.join(projectDir, 'node_modules/.bin/aegir'), 0o755)
+  }
 
   return projectDir
 }

--- a/tsconfig-check.aegir.json
+++ b/tsconfig-check.aegir.json
@@ -1,0 +1,1 @@
+{"extends":"./src/config/tsconfig.aegir.json","compilerOptions":{"outDir":"dist","emitDeclarationOnly":false,"noEmit":true},"include":["package.json","src","test","utils"]}


### PR DESCRIPTION
Since esbuild is run over browser tests, we want to pass the uncompiled versions to the test runner, otherwise esbuild doesn't match the browser overrides from the project's package.json.