### PR TITLE
fix: run compiled tests

### DIFF
--- a/src/build/index.js
+++ b/src/build/index.js
@@ -6,7 +6,7 @@ import path from 'path'
 import fs from 'fs-extra'
 import pascalcase from 'pascalcase'
 import bytes from 'bytes'
-import { gzipSize, pkg, hasTsconfig, hasFile, fromRoot, paths } from './../utils.js'
+import { gzipSize, pkg, hasTsconfig, isTypescript, hasFile, fromRoot, paths } from './../utils.js'
 import { execa } from 'execa'
 import merge from 'merge-options'
 
@@ -30,10 +30,11 @@ const build = async (argv) => {
   const globalName = pascalcase(pkg.name)
   const umdPre = `(function (root, factory) {(typeof module === 'object' && module.exports) ? module.exports = factory() : root.${globalName} = factory()}(typeof self !== 'undefined' ? self : this, function () {`
   const umdPost = `return ${globalName}}));`
+  let entryPoint = fromRoot('src', 'index.js')
 
-  const tsIndex = fromRoot('src', 'index.ts')
-  const jsIndex = fromRoot('src', 'index.js')
-  const entryPoint = hasFile(tsIndex) ? tsIndex : jsIndex
+  if (isTypescript) {
+    entryPoint = fromRoot('dist', 'src', 'index.js')
+  }
 
   const result = await esbuild.build(defaults(
     {

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -6,7 +6,7 @@ import path from 'path'
 import fs from 'fs-extra'
 import pascalcase from 'pascalcase'
 import bytes from 'bytes'
-import { gzipSize, pkg, hasTsconfig, isTypescript, hasFile, fromRoot, paths } from './../utils.js'
+import { gzipSize, pkg, hasTsconfig, isTypescript, fromRoot, paths } from './../utils.js'
 import { execa } from 'execa'
 import merge from 'merge-options'
 

--- a/src/test/browser.js
+++ b/src/test/browser.js
@@ -30,8 +30,10 @@ export default async (argv, execaOptions) => {
   const files = argv.files.length > 0
     ? argv.files
     : [
-        'test/**/*.spec.{js,ts,cjs,mjs}',
-        'test/browser.{js,ts,cjs,mjs}'
+        'test/**/*.spec.{js,cjs,mjs}',
+        'test/browser.{js,cjs,mjs}',
+        'dist/test/**/*.spec.{js,cjs,mjs}',
+        'dist/test/browser.{js,cjs,mjs}'
       ]
 
   // before hook

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -26,7 +26,7 @@ const TASKS = [
      * @param {BuildOptions & GlobalOptions} ctx
      */
     task: async (ctx) => {
-      await execa('npm', ['run', 'build', '--if-present'], {
+      await execa('npm', ['run', 'build', '--if-present', '--', '--no-bundle'], {
         stdio: 'inherit'
       })
     }


### PR DESCRIPTION
In order to not have to declare browser overrides for both `src` and `dist`, run tests on the compiled test output for ts projects.