### PR TITLE
fix: make resolve node-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
       "import": "./utils/get-port.js"
     },
     "./resolve": {
+      "browser": "./utils/resolve.browser.js",
       "import": "./utils/resolve.js"
     }
   },
@@ -287,6 +288,7 @@
   },
   "browser": {
     "fs": false,
-    "./utils/fixtures.js": "./utils/fixtures.browser.js"
+    "./utils/fixtures.js": "./utils/fixtures.browser.js",
+    "./utils/resolve.js": "./utils/resolve.browser.js"
   }
 }

--- a/tsconfig-check.aegir.json
+++ b/tsconfig-check.aegir.json
@@ -1,1 +1,0 @@
-{"extends":"./src/config/tsconfig.aegir.json","compilerOptions":{"outDir":"dist","emitDeclarationOnly":false,"noEmit":true},"include":["package.json","src","test","utils"]}

--- a/utils/resolve.browser.js
+++ b/utils/resolve.browser.js
@@ -4,6 +4,6 @@
  * @param {string} filePath
  * @param {string} [module]
  */
- export default function resolve (filePath, module = '') {
+export default function resolve (filePath, module = '') {
   throw new Error('Not supported in the browser')
 }

--- a/utils/resolve.browser.js
+++ b/utils/resolve.browser.js
@@ -1,0 +1,9 @@
+/**
+ * Returns the full path to the requested resource, if available
+ *
+ * @param {string} filePath
+ * @param {string} [module]
+ */
+ export default function resolve (filePath, module = '') {
+  throw new Error('Not supported in the browser')
+}


### PR DESCRIPTION
Resolve requires use of node features so add browser overrides to ensure it's not pulled in during bundling.