### PR TITLE
fix: run dep check in prod mode

### DIFF
--- a/src/cmds/dependency-check.js
+++ b/src/cmds/dependency-check.js
@@ -30,20 +30,7 @@ export default {
       .positional('input', {
         describe: 'Files to check',
         type: 'string',
-        array: true,
-        default: userConfig.dependencyCheck.input
-      })
-      .option('p', {
-        alias: 'production-only',
-        describe: 'Check production dependencies and paths only',
-        type: 'boolean',
-        default: userConfig.dependencyCheck.productionOnly
-      })
-      .option('I', {
-        alias: 'production-input',
-        describe: 'Files to check when in production only mode',
-        type: 'string',
-        default: userConfig.dependencyCheck.productionInput
+        array: true
       })
       .option('i', {
         alias: 'ignore',

--- a/src/cmds/dependency-check.js
+++ b/src/cmds/dependency-check.js
@@ -39,6 +39,12 @@ export default {
         type: 'boolean',
         default: userConfig.dependencyCheck.productionOnly
       })
+      .option('I', {
+        alias: 'production-input',
+        describe: 'Files to check when in production only mode',
+        type: 'string',
+        default: userConfig.dependencyCheck.productionInput
+      })
       .option('i', {
         alias: 'ignore',
         describe: 'Ignore these dependencies when considering which are used and which are not',

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -110,8 +110,15 @@ const defaults = {
     productionOnly: false,
     productionInput: [
       'package.json',
+      '.aegir.js',
+      '.aegir.cjs',
       'src/**/*.js',
-      'src/**/*.cjs'
+      'src/**/*.cjs',
+      'dist/src/**/*.js',
+      'utils/**/*.js',
+      'utils/**/*.cjs',
+      '!./test/fixtures/**/*.js',
+      '!./test/fixtures/**/*.cjs'
     ],
     ignore: [
       '@types/*'

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -110,15 +110,11 @@ const defaults = {
     productionOnly: false,
     productionInput: [
       'package.json',
-      '.aegir.js',
-      '.aegir.cjs',
       'src/**/*.js',
       'src/**/*.cjs',
       'dist/src/**/*.js',
       'utils/**/*.js',
-      'utils/**/*.cjs',
-      '!./test/fixtures/**/*.js',
-      '!./test/fixtures/**/*.cjs'
+      'utils/**/*.cjs'
     ],
     ignore: [
       '@types/*'

--- a/src/dependency-check.js
+++ b/src/dependency-check.js
@@ -13,13 +13,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
  * @typedef {import("./types").DependencyCheckOptions} DependencyCheckOptions
  */
 
-/**
- * @param {any} arr1
- * @param {any} arr2
- */
-const isDefaultInput = (arr1, arr2) =>
-  JSON.stringify(arr1) === JSON.stringify(arr2)
-
 const tasks = new Listr(
   [
     {
@@ -30,17 +23,47 @@ const tasks = new Listr(
        */
       task: async (ctx, task) => {
         const forwardOptions = ctx['--'] ? ctx['--'] : []
-        const input =
-            ctx.productionOnly &&
-              isDefaultInput(ctx.fileConfig.dependencyCheck.input, ctx.input)
-              ? ctx.fileConfig.dependencyCheck.productionInput
-              : ctx.input
-        const noDev = ctx.productionOnly ? ['--no-dev'] : []
+        const input = ctx.input
         const ignore = ctx.ignore
           .concat(ctx.fileConfig.dependencyCheck.ignore)
           .reduce((acc, i) => acc.concat('-i', i), /** @type {string[]} */ ([]))
 
-        const args = [...input, '--missing', ...noDev, ...ignore]
+        const args = [...input, '--missing', ...ignore]
+
+        if (pkg.type === 'module') {
+          // use detective-es6 for js, regular detective for cjs
+          args.push(
+            '--extensions', 'cjs:detective-cjs',
+            '--extensions', 'js:detective-es6'
+          )
+        }
+
+        await execa(
+          'dependency-check',
+          [...args, ...forwardOptions],
+          merge(
+            {
+              localDir: path.join(__dirname, '..'),
+              preferLocal: true
+            }
+          )
+        )
+      }
+    },
+    {
+      title: 'dependency-check (production only)',
+      /**
+       * @param {GlobalOptions & DependencyCheckOptions} ctx
+       * @param {Task} task
+       */
+      task: async (ctx, task) => {
+        const forwardOptions = ctx['--'] ? ctx['--'] : []
+        const input = ctx.fileConfig.dependencyCheck.productionInput
+        const ignore = ctx.ignore
+          .concat(ctx.fileConfig.dependencyCheck.ignore)
+          .reduce((acc, i) => acc.concat('-i', i), /** @type {string[]} */ ([]))
+
+        const args = [...input, '--missing', '--no-dev', ...ignore]
 
         if (pkg.type === 'module') {
           // use detective-es6 for js, regular detective for cjs

--- a/src/dependency-check.js
+++ b/src/dependency-check.js
@@ -23,7 +23,7 @@ const tasks = new Listr(
        */
       task: async (ctx, task) => {
         const forwardOptions = ctx['--'] ? ctx['--'] : []
-        const input = ctx.input
+        const input = ctx.input.length > 0 ? ctx.input : ctx.fileConfig.dependencyCheck.input
         const ignore = ctx.ignore
           .concat(ctx.fileConfig.dependencyCheck.ignore)
           .reduce((acc, i) => acc.concat('-i', i), /** @type {string[]} */ ([]))
@@ -58,7 +58,7 @@ const tasks = new Listr(
        */
       task: async (ctx, task) => {
         const forwardOptions = ctx['--'] ? ctx['--'] : []
-        const input = ctx.fileConfig.dependencyCheck.productionInput
+        const input = ctx.input.length > 0 ? ctx.input : ctx.fileConfig.dependencyCheck.productionInput
         const ignore = ctx.ignore
           .concat(ctx.fileConfig.dependencyCheck.ignore)
           .reduce((acc, i) => acc.concat('-i', i), /** @type {string[]} */ ([]))


### PR DESCRIPTION
Run dep check command twice - once to check all deps of a project are
present and once again to only check production code for production
deps in order to catch the instance when we add a production dep to
the dev deps list.