### PR TITLE
chore: update lilconfig version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "globby": "^13.1.1",
     "it-glob": "^1.0.1",
     "kleur": "^4.1.4",
-    "lilconfig": "^2.0.2",
+    "lilconfig": "^2.0.5",
     "listr": "~0.14.2",
     "merge-options": "^3.0.4",
     "mocha": "^9.0.2",


### PR DESCRIPTION
For some reason in my dep tree, npm always resolves lilconfig@2.0.4 which has bug with async loading (fixed in 2.0.5: https://github.com/antonk52/lilconfig/commit/0f68c45a9c4c763131117dc86b537349434e2299). 

That bug surfaces in libp2p with the following error:
```
TypeError: `[object Promise]` is not an Option Object
    at module.exports (libp2p/js-libp2p/node_modules/merge-options/index.js:164:10)
    at config (libp2p/js-libp2p/node_modules/aegir/src/config/user.js:168:39)
    at async main (libp2p/js-libp2p/node_modules/aegir/src/index.js:35:22)
```

After I forced 2.0.5 version, npm resolves correct version but this will ensure nobody resolves buggy version