### PR TITLE
fix: ignore minified files and transpiled fixtures in dep-check

### DIFF
--- a/src/config/user.js
+++ b/src/config/user.js
@@ -105,7 +105,10 @@ const defaults = {
       'utils/**/*.js',
       'utils/**/*.cjs',
       '!./test/fixtures/**/*.js',
-      '!./test/fixtures/**/*.cjs'
+      '!./test/fixtures/**/*.cjs',
+      '!./dist/test/fixtures/**/*.js',
+      '!./dist/test/fixtures/**/*.cjs',
+      '!**/*.min.js'
     ],
     productionOnly: false,
     productionInput: [


### PR DESCRIPTION
Add ignores for files like `index.min.js` and any fixtures in the dist folder when checking dependencies.