### PR TITLE
fix: sort exports map

### DIFF
--- a/src/check-project/manifests/typed-esm.js
+++ b/src/check-project/manifests/typed-esm.js
@@ -2,6 +2,7 @@ import { semanticReleaseConfig } from '../semantic-release-config.js'
 import mergeOptions from 'merge-options'
 import {
   sortFields,
+  sortExportsMap,
   constructManifest
 } from '../utils.js'
 
@@ -39,9 +40,10 @@ export async function typedESMManifest (manifest, branchName, repoUrl, homePage 
       '!dist/test',
       '!**/*.tsbuildinfo'
     ],
-    exports: sortFields(
+    exports: sortExportsMap(
       merge({
         '.': {
+          types: './src/index.d.ts',
           import: './src/index.js'
         }
       }, manifest.exports)

--- a/src/check-project/manifests/typescript.js
+++ b/src/check-project/manifests/typescript.js
@@ -4,6 +4,7 @@ import { semanticReleaseConfig } from '../semantic-release-config.js'
 import mergeOptions from 'merge-options'
 import {
   sortFields,
+  sortExportsMap,
   constructManifest
 } from '../utils.js'
 
@@ -26,9 +27,10 @@ export async function typescriptManifest (manifest, branchName, repoUrl, homePag
       '!dist/test',
       '!**/*.tsbuildinfo'
     ],
-    exports: sortFields(
+    exports: sortExportsMap(
       merge({
         '.': {
+          types: './src/index.d.ts',
           import: './dist/src/index.js'
         }
       }, manifest.exports)

--- a/src/check-project/utils.js
+++ b/src/check-project/utils.js
@@ -161,6 +161,34 @@ export function sortFields (obj) {
 }
 
 /**
+ * @param {Record<string, any>} obj
+ */
+ export function sortExportsMap (obj) {
+  /** @type {Record<string, any>} */
+  const output = {}
+  const sorted = sortFields(obj) ?? {}
+
+  for (const key of Object.keys(sorted)) {
+    const entry = sorted[key]
+    let types = entry.types
+
+    if (!types) {
+      types = entry.import.replace('\.js', '.d.ts')
+    }
+
+    delete entry.types
+
+    output[key] = {
+      // types field must be first - https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing
+      types,
+      ...entry
+    }
+  }
+
+  return output
+}
+
+/**
  * @param {any} manifest
  */
 export function sortManifest (manifest) {

--- a/src/check-project/utils.js
+++ b/src/check-project/utils.js
@@ -163,7 +163,7 @@ export function sortFields (obj) {
 /**
  * @param {Record<string, any>} obj
  */
- export function sortExportsMap (obj) {
+export function sortExportsMap (obj) {
   /** @type {Record<string, any>} */
   const output = {}
   const sorted = sortFields(obj) ?? {}
@@ -173,7 +173,7 @@ export function sortFields (obj) {
     let types = entry.types
 
     if (!types) {
-      types = entry.import.replace('\.js', '.d.ts')
+      types = entry.import.replace('.js', '.d.ts')
     }
 
     delete entry.types


### PR DESCRIPTION
Make sure types field is first in the exports map for TypeScript 4.7