### PR TITLE
fix: output coverage to .coverage dir

### DIFF
--- a/src/test/browser.js
+++ b/src/test/browser.js
@@ -26,7 +26,7 @@ export default async (argv, execaOptions) => {
     argv.bail && '--bail'
   ].filter(Boolean))
   const watch = argv.watch ? ['--watch'] : []
-  const cov = argv.cov ? ['--cov'] : []
+  const cov = argv.cov ? ['--cov', '--report-dir', '.coverage'] : []
   const files = argv.files.length > 0
     ? argv.files
     : [

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -23,7 +23,7 @@ export default async function testNode (argv, execaOptions) {
   const covArgs = argv.cov
     ? [
         '--reporter', 'json',
-        '--report-dir', '.nyc_output',
+        '--report-dir', '.coverage',
         '--temp-directory', tempy.directory(),
         '--clean',
         'mocha'


### PR DESCRIPTION
In order for the codecov github action to find coverage reports in monorepos, output coverage reports to a known location.