### PR TITLE
fix: update typescript, esbuild, tempy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn.lock
 .nyc_output
 *.log
 .vscode
+/tsconfig-check.aegir.json

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "source-map-support": "^0.5.20",
     "strip-bom": "^5.0.0",
     "strip-json-comments": "^4.0.0",
-    "tempy": "^2.0.0",
+    "tempy": "^3.0.0",
     "typescript": "^4.6.3",
     "uint8arrays": "^3.0.0",
     "undici": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "env-paths": "^3.0.0",
     "esbuild": "^0.14.46",
     "eslint": "^8.12.0",
-    "eslint-config-ipfs": "^2.1.0",
+    "eslint-config-ipfs": "^2.1.2",
     "eslint-plugin-etc": "^2.0.2",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsdoc": "^39.0.0",

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "strip-bom": "^5.0.0",
     "strip-json-comments": "^4.0.0",
     "tempy": "^3.0.0",
-    "typescript": "^4.6.3",
+    "typescript": "^4.7.4",
     "uint8arrays": "^3.0.0",
     "undici": "^5.0.0",
     "update-notifier": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "detective-es6": "^3.0.0",
     "electron-mocha-main": "^11.0.3",
     "env-paths": "^3.0.0",
-    "esbuild": "^0.14.31",
+    "esbuild": "^0.14.46",
     "eslint": "^8.12.0",
     "eslint-config-ipfs": "^2.1.0",
     "eslint-plugin-etc": "^2.0.2",

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -1,6 +1,6 @@
 import { execa } from 'execa'
 import path from 'path'
-import tempy from 'tempy'
+import { temporaryDirectory } from 'tempy'
 import merge from 'merge-options'
 import { fileURLToPath } from 'url'
 
@@ -24,7 +24,7 @@ export default async function testNode (argv, execaOptions) {
     ? [
         '--reporter', 'json',
         '--report-dir', '.coverage',
-        '--temp-directory', tempy.directory(),
+        '--temp-directory', temporaryDirectory(),
         '--clean',
         'mocha'
       ]

--- a/test/build.js
+++ b/test/build.js
@@ -4,7 +4,7 @@ import { expect } from '../utils/chai.js'
 import { execa } from 'execa'
 import fs from 'fs-extra'
 import path, { join } from 'path'
-import tempy from 'tempy'
+import { temporaryDirectory } from 'tempy'
 import { fileURLToPath } from 'url'
 import { createRequire } from 'module'
 
@@ -17,7 +17,7 @@ describe('build', () => {
     let projectDir = ''
 
     before(async () => {
-      projectDir = tempy.directory()
+      projectDir = temporaryDirectory()
 
       await fs.copy(join(__dirname, 'fixtures', 'projects', 'an-esm-project'), projectDir)
     })

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@
 import { execa } from 'execa'
 import fs, { copy } from 'fs-extra'
 import path, { join } from 'path'
-import tempy from 'tempy'
+import { temporaryDirectory } from 'tempy'
 import { fileURLToPath } from 'url'
 import os from 'os'
 
@@ -13,7 +13,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
  * @param {string} project
  */
 async function setUpProject (project) {
-  const projectDir = tempy.directory()
+  const projectDir = temporaryDirectory()
 
   await copy(join(__dirname, 'fixtures', 'projects', project), projectDir)
   const nodeModulesPath = path.resolve(__dirname, '../node_modules')


### PR DESCRIPTION
Fixes an error when building where "es2021" is not in the list of known versions.

Refactor for import path changes required when upgrading to tempy 3.0.0