### PR TITLE
fix: remove no-bundle from test build and fix flag

### DIFF
--- a/src/config/user.js
+++ b/src/config/user.js
@@ -14,7 +14,7 @@ const defaults = {
   debug: false,
   // test cmd options
   test: {
-    build: false,
+    build: true,
     runner: 'node',
     target: ['node', 'browser', 'webworker'],
     watch: false,

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -3,7 +3,6 @@ import node from './node.js'
 import browser from './browser.js'
 import electron from './electron.js'
 import rn from './react-native.js'
-import { isTypescript } from '../utils.js'
 import { execa } from 'execa'
 
 /**
@@ -20,13 +19,13 @@ const TASKS = [
     /**
      * @param {TestOptions & GlobalOptions} ctx
      */
-    enabled: (ctx) => isTypescript || ctx.build === true,
+    enabled: (ctx) => ctx.build === true,
 
     /**
      * @param {BuildOptions & GlobalOptions} ctx
      */
     task: async (ctx) => {
-      await execa('npm', ['run', 'build', '--if-present', '--', '--no-bundle'], {
+      await execa('npm', ['run', 'build', '--if-present'], {
         stdio: 'inherit'
       })
     }


### PR DESCRIPTION
We run build before test but pass `--no-bundle` on the assumption that a project build command is `aegir build`.  Passing `--no-bundle` skips making a minified build for a tiny speedup.

If the project build command isn't `aegir build` this can break things so remove the optimisation.

Also build by default before test (to support typescript) and fix the problem whereby the build flag was being ignored for typescript projects.

Fixes: #975