### PR TITLE
feat: align monorepo sibling versions

### DIFF
--- a/src/cmds/release.js
+++ b/src/cmds/release.js
@@ -1,4 +1,5 @@
 import releaseCmd from '../release.js'
+import { loadUserConfig } from '../config/user.js'
 
 /**
  * @typedef {import("yargs").Argv} Argv
@@ -18,8 +19,18 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
+    const userConfig = await loadUserConfig()
+
     return yargs
       .epilog(EPILOG)
+      .options({
+        siblingDepUpdateMessage: {
+          alias: 'm',
+          type: 'string',
+          describe: 'Automatically fix errors if possible.',
+          default: userConfig.release.siblingDepUpdateMessage
+        }
+      })
   },
   /**
    * @param {any} argv

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -88,7 +88,9 @@ const defaults = {
     preid: undefined,
     distTag: 'latest',
     remote: 'origin',
-    siblingDepUpdateMessage: 'chore: update sibling dependencies [skip ci]'
+    siblingDepUpdateMessage: 'chore: update sibling dependencies [skip ci]',
+    siblingDepUpdateName: 'semantic-release-bot',
+    siblingDepUpdateEmail: 'semantic-release-bot@martynus.net'
   },
   // dependency check cmd options
   dependencyCheck: {

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -87,7 +87,8 @@ const defaults = {
     type: 'patch',
     preid: undefined,
     distTag: 'latest',
-    remote: 'origin'
+    remote: 'origin',
+    siblingDepUpdateMessage: 'chore: update sibling dependencies [skip ci]'
   },
   // dependency check cmd options
   dependencyCheck: {

--- a/src/release.js
+++ b/src/release.js
@@ -107,6 +107,15 @@ const tasks = new Listr([
         return
       }
 
+      // When running on CI, set the commits author and commiter info and prevent the `git` CLI to prompt for username/password.
+      // Borrowed from `semantic-release`
+      process.env.GIT_AUTHOR_NAME = ctx.siblingDepUpdateName
+      process.env.GIT_AUTHOR_EMAIL = ctx.siblingDepUpdateEmail
+      process.env.GIT_COMMITTER_NAME = ctx.siblingDepUpdateName
+      process.env.GIT_COMMITTER_EMAIL = ctx.siblingDepUpdateEmail
+      process.env.GIT_ASKPASS = 'echo'
+      process.env.GIT_TERMINAL_PROMPT = '0'
+
       console.info(`Commit with message "${ctx.siblingDepUpdateMessage}"`) // eslint-disable-line no-console
       await execa('git', ['add', '-A'], {
         cwd: rootDir

--- a/src/types.ts
+++ b/src/types.ts
@@ -262,6 +262,16 @@ interface ReleaseOptions {
    * it's siblings change, use this as the commit message
    */
   siblingDepUpdateMessage: string
+
+  /**
+   * The name to use in a git commit that update sibling deps
+   */
+   siblingDepUpdateName: string
+
+   /**
+   * The email to use in a git commit that update sibling deps
+   */
+   siblingDepUpdateEmail: string
 }
 
 interface DependencyCheckOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,12 +266,12 @@ interface ReleaseOptions {
   /**
    * The name to use in a git commit that update sibling deps
    */
-   siblingDepUpdateName: string
+  siblingDepUpdateName: string
 
-   /**
+  /**
    * The email to use in a git commit that update sibling deps
    */
-   siblingDepUpdateEmail: string
+  siblingDepUpdateEmail: string
 }
 
 interface DependencyCheckOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,6 +257,11 @@ interface ReleaseOptions {
    * Git remote
    */
   remote: string
+  /**
+   * During a monorepo release, if a package release means the dependencies of
+   * it's siblings change, use this as the commit message
+   */
+  siblingDepUpdateMessage: string
 }
 
 interface DependencyCheckOptions {


### PR DESCRIPTION
We use `semantic-release-monorepo` to publish packages in monorepos.

We use `lerna` to work out sibling cross-dependencies to ensure we publish in the correct order.

This all seems to work ok, but `semantic-release-monorepo` doesn't update dependency versions for cross-dependent siblings when they change.

We can lean on semver ranges to take care of this for the most part but it breaks when we release a major version of a sibling.  In this case the other siblings have been coded against the new API but still depend on the old version which breaks.

This pr adds a job to the release command that, if we are a monorepo, synchronises the versions of all sibling dependencies after each publish.