### PR TITLE
fix: ignore aegir during dep-check

### DIFF
--- a/src/config/user.js
+++ b/src/config/user.js
@@ -120,6 +120,7 @@ const defaults = {
       'utils/**/*.cjs'
     ],
     ignore: [
+      'aegir',
       '@types/*'
     ]
   }

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -120,8 +120,8 @@ const defaults = {
       'utils/**/*.cjs'
     ],
     ignore: [
-      'aegir',
-      '@types/*'
+      '@types/*',
+      'aegir'
     ]
   }
 }


### PR DESCRIPTION
Ignore aegir not being used in code as we're using it to run the dep-check so, uh, it is used.