### PR TITLE
fix: add Documentation and Dependencies to release notes

### DIFF
--- a/src/check-project/files/.github/dependabot.yml
+++ b/src/check-project/files/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: "deps"
+    prefix-development: "deps(dev)"

--- a/src/check-project/semantic-release-config.js
+++ b/src/check-project/semantic-release-config.js
@@ -52,7 +52,10 @@ export const semanticReleaseConfig = (branchName) => {
               section: 'Trivial Changes'
             }, {
               type: 'docs',
-              section: 'Trivial Changes'
+              section: 'Documentation'
+            }, {
+              type: 'deps',
+              section: 'Dependencies'
             }, {
               type: 'test',
               section: 'Tests'


### PR DESCRIPTION
Generate release notes with `Documentation` section from commits
prefixed with `docs:` and `Dependencies` from commits tagged with
`deps:` and `deps(dev):`.

Configure dependabot to add the `deps:` and `deps(dev):` prefixes.

Interested projects should run `npx aegir check-project` to get the
updated config.