### PR TITLE
fix: add fallback for project license and badges

### DIFF
--- a/src/check-project/check-monorepo-readme.js
+++ b/src/check-project/check-monorepo-readme.js
@@ -110,7 +110,7 @@ export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, p
     parsedReadme.children.push(child)
   })
 
-  const license = parseMarkdown(LICENSE[repoOwner])
+  const license = parseMarkdown(LICENSE[repoOwner] ?? LICENSE.default)
   const structure = parseMarkdown(STRUCTURE(projectDir, projectDirs))
 
   parsedReadme.children = [

--- a/src/check-project/check-readme.js
+++ b/src/check-project/check-readme.js
@@ -110,7 +110,7 @@ export async function checkReadme (projectDir, repoUrl, defaultBranch) {
   })
 
   const installation = parseMarkdown(INSTALL(pkg))
-  const license = parseMarkdown(LICENSE[repoOwner])
+  const license = parseMarkdown(LICENSE[repoOwner] ?? LICENSE.default)
 
   parsedReadme.children = [
     ...installation.children,

--- a/src/check-project/readme/header.js
+++ b/src/check-project/readme/header.js
@@ -17,9 +17,13 @@ const BADGES = {
 [![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-interfaces/test%20&%20maybe%20release/${defaultBranch}?style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/js-test-and-release.yml)
 `,
   multiformats: (repoOwner, repoName, defaultBranch) => `
-  [![multiformats.io](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://multiformats.io)
-  [![codecov](https://img.shields.io/codecov/c/github/${repoOwner}/${repoName}.svg?style=flat-square)](https://codecov.io/gh/${repoOwner}/${repoName})
-  [![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-interfaces/test%20&%20maybe%20release/${defaultBranch}?style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/js-test-and-release.yml)
+[![multiformats.io](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://multiformats.io)
+[![codecov](https://img.shields.io/codecov/c/github/${repoOwner}/${repoName}.svg?style=flat-square)](https://codecov.io/gh/${repoOwner}/${repoName})
+[![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-interfaces/test%20&%20maybe%20release/${defaultBranch}?style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/js-test-and-release.yml)
+  `,
+  default: (repoOwner, repoName, defaultBranch) => `
+[![codecov](https://img.shields.io/codecov/c/github/${repoOwner}/${repoName}.svg?style=flat-square)](https://codecov.io/gh/${repoOwner}/${repoName})
+[![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-interfaces/test%20&%20maybe%20release/${defaultBranch}?style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/js-test-and-release.yml)
   `
 }
 
@@ -33,7 +37,7 @@ export const HEADER = (pkg, repoOwner, repoName, defaultBranch) => {
   return `
 # ${pkg.name} <!-- omit in toc -->
 
-${BADGES[repoOwner](repoOwner, repoName, defaultBranch).trim()}
+${(BADGES[repoOwner] ?? BADGES.default)(repoOwner, repoName, defaultBranch).trim()}
 
 > ${pkg.description}
 

--- a/src/check-project/readme/license.js
+++ b/src/check-project/readme/license.js
@@ -1,18 +1,6 @@
 
 /** @type {Record<string, string>} */
 export const LICENSE = {
-  libp2p: `
-## License
-
-Licensed under either of
-
-  * Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / http://www.apache.org/licenses/LICENSE-2.0)
-  * MIT ([LICENSE-MIT](LICENSE-MIT) / http://opensource.org/licenses/MIT)
-
-## Contribution
-
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
-`,
   ipfs: `
 ## License
 
@@ -29,7 +17,7 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 
 [![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)
 `,
-  multiformats: `
+  default: `
 ## License
 
 Licensed under either of


### PR DESCRIPTION
When the repo owner doesn't have a specific type of badge set or
license, fall back to a default version.