### PR TITLE
feat: tell lerna to use npm workspaces

### DIFF
--- a/src/check-project/files/lerna.json
+++ b/src/check-project/files/lerna.json
@@ -1,8 +1,6 @@
 {
   "lerna": "4.0.0",
-  "packages": [
-    "packages/*"
-  ],
+  "useWorkspaces": true,
   "version": "independent",
   "command": {
     "run": {


### PR DESCRIPTION
lerna supports parsing workspace path defs from `package.json` so use that in order to silence the warning you otherwise see.