### PR TITLE
fix: preserve readme definitions when checking project config

### DIFF
--- a/src/check-project/check-licence-files.js
+++ b/src/check-project/check-licence-files.js
@@ -1,7 +1,7 @@
 
 /* eslint-disable no-console */
 
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import chalk from 'chalk'
 import {
@@ -14,9 +14,7 @@ import {
 export async function checkLicenseFiles (projectDir) {
   console.info('Check license files')
 
-  const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), {
-    encoding: 'utf-8'
-  }))
+  const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
 
   if (pkg.license !== 'Apache-2.0 OR MIT') {
     throw new Error(`Incorrect license field - found '${pkg.license}', expected 'Apache-2.0 OR MIT'`)

--- a/src/check-project/check-monorepo-files.js
+++ b/src/check-project/check-monorepo-files.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import {
   ensureFileHasContents
@@ -15,9 +15,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 export async function checkMonorepoFiles (projectDir) {
   console.info('Check monorepo files')
 
-  const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), {
-    encoding: 'utf-8'
-  }))
+  const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
 
   let defaultLernaContent = fs.readFileSync(path.join(__dirname, 'files/lerna.json'), {
     encoding: 'utf-8'

--- a/src/check-project/check-monorepo-readme.js
+++ b/src/check-project/check-monorepo-readme.js
@@ -1,7 +1,7 @@
 
 /* eslint-disable no-console */
 
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import {
   ensureFileHasContents
@@ -29,9 +29,7 @@ export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, p
 
   console.info('Check README files')
 
-  const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), {
-    encoding: 'utf-8'
-  }))
+  const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
 
   const readmePath = path.join(projectDir, 'README.md')
   let readmeContents = ''

--- a/src/check-project/files/lerna.json
+++ b/src/check-project/files/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "4.0.0",
+  "lerna": "5.4.0",
   "useWorkspaces": true,
   "version": "independent",
   "command": {

--- a/src/check-project/index.js
+++ b/src/check-project/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console,complexity */
 
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 import { execa } from 'execa'
 import prompt from 'prompt'
@@ -106,10 +106,7 @@ async function processMonorepo (projectDir, manifest, branchName, repoUrl) {
       cwd: projectDir,
       absolute: true
     })) {
-      const pkg = JSON.parse(fs.readFileSync(path.join(subProjectDir, 'package.json'), {
-        encoding: 'utf-8'
-      }))
-
+      const pkg = fs.readJSONSync(path.join(subProjectDir, 'package.json'))
       const homePage = `${repoUrl}/tree/master${subProjectDir.substring(projectDir.length)}`
 
       console.info('Found monorepo project', pkg.name)
@@ -152,10 +149,7 @@ async function alignMonorepoProjectDependencies (projectDirs) {
 
   // first loop over every project and choose the most recent version of a given dep
   for (const projectDir of projectDirs) {
-    const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), {
-      encoding: 'utf-8'
-    }))
-
+    const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
     siblingVersions[pkg.name] = calculateSiblingVersion(pkg.version)
 
     chooseVersions(pkg.dependencies || {}, deps)
@@ -166,9 +160,7 @@ async function alignMonorepoProjectDependencies (projectDirs) {
 
   // now propose the most recent version of a dep for all projects
   for (const projectDir of projectDirs) {
-    const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), {
-      encoding: 'utf-8'
-    }))
+    const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
 
     selectVersions(pkg.dependencies || {}, deps, siblingVersions)
     selectVersions(pkg.devDependencies || {}, devDeps, siblingVersions)
@@ -233,9 +225,7 @@ async function configureMonorepoProjectReferences (projectDirs) {
 
   // first loop over every project and choose the most recent version of a given dep
   for (const projectDir of projectDirs) {
-    const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), {
-      encoding: 'utf-8'
-    }))
+    const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
 
     references[pkg.name] = projectDir
   }
@@ -247,14 +237,8 @@ async function configureMonorepoProjectReferences (projectDirs) {
       continue
     }
 
-    const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), {
-      encoding: 'utf-8'
-    }))
-
-    const tsconfig = JSON.parse(fs.readFileSync(path.join(projectDir, 'tsconfig.json'), {
-      encoding: 'utf-8'
-    }))
-
+    const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
+    const tsconfig = fs.readJSONSync(path.join(projectDir, 'tsconfig.json'))
     const refs = new Set()
 
     addReferences(pkg.dependencies || {}, references, refs)
@@ -406,11 +390,7 @@ export default new Listr([
     task: async () => {
       const projectDir = process.argv[3] || process.cwd()
       const { branchName, repoUrl } = await getConfig(projectDir)
-
-      const manifest = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), {
-        encoding: 'utf-8'
-      }))
-
+      const manifest = fs.readJSONSync(path.join(projectDir, 'package.json'))
       const monorepo = manifest.workspaces != null
 
       if (monorepo) {

--- a/src/check-project/readme/structure.js
+++ b/src/check-project/readme/structure.js
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs-extra'
 import path from 'path'
 
 /**
@@ -10,9 +10,7 @@ export const STRUCTURE = (monorepoDir, projectDirs) => {
   const packages = {}
 
   for (const projectDir of projectDirs.sort()) {
-    const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), {
-      encoding: 'utf-8'
-    }))
+    const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
 
     const key = projectDir.replace(monorepoDir, '')
 

--- a/src/check-project/utils.js
+++ b/src/check-project/utils.js
@@ -28,12 +28,19 @@ export async function ensureFileHasContents (projectDir, filePath, expectedConte
   let existingContents = ''
 
   if (fileExists) {
-    existingContents = fs.readFileSync(path.join(projectDir, filePath), {
+    const existingFilePath = path.join(projectDir, filePath)
+    existingContents = fs.readFileSync(existingFilePath, {
       encoding: 'utf-8'
     })
 
     if (filePath.endsWith('.json')) {
-      existingContents = JSON.stringify(JSON.parse(existingContents), null, 2) + '\n'
+      try {
+        existingContents = JSON.stringify(JSON.parse(existingContents), null, 2) + '\n'
+      } catch (err) {
+        console.error('Could not parse', existingFilePath, 'as JSON')
+
+        throw err
+      }
     }
   } else {
     if (process.env.CI) {


### PR DESCRIPTION
Also print useful error messages when parsing a file as JSON fails (e.g. print out which file)