### PR TITLE
fix: ignore single-import from exports map

### DIFF
--- a/src/check-project/utils.js
+++ b/src/check-project/utils.js
@@ -177,6 +177,13 @@ export function sortExportsMap (obj) {
 
   for (const key of Object.keys(sorted)) {
     const entry = sorted[key]
+
+    // ignore case where obj has string props, e.g. `"exports": { "import": "./src/index.js" }`
+    // as we have already merged `"exports": { ".": { "import": "./src/index.js" } }`
+    if (typeof entry === 'string') {
+      continue
+    }
+
     let types = entry.types
 
     if (!types) {

--- a/src/cmds/check-project.js
+++ b/src/cmds/check-project.js
@@ -27,7 +27,7 @@ export default {
   async handler (argv) {
     await checkProjectCmd.run(argv)
       .catch(err => {
-        console.error(err)
+        console.error(err) // eslint-disable-line no-console
         process.exit(1)
       })
   }

--- a/src/cmds/check-project.js
+++ b/src/cmds/check-project.js
@@ -26,5 +26,9 @@ export default {
    */
   async handler (argv) {
     await checkProjectCmd.run(argv)
+      .catch(err => {
+        console.error(err)
+        process.exit(1)
+      })
   }
 }


### PR DESCRIPTION
Because we merge an object with the `"."` style export, ignore any single-export style fields.