### PR TITLE
feat: build opt-out for cache-node-modules action

### DIFF
--- a/actions/cache-node-modules/action.yml
+++ b/actions/cache-node-modules/action.yml
@@ -7,6 +7,11 @@ inputs:
   build:
     description: 'Extra commands to run if nothing is cached'
     required: false
+    default: 'echo'
+  build_on_cache_fail:
+    description: 'Whether you want to run `npm run --if-present build` if there is no cache
+    require: false
+    default: 'true' # defaulting to true to not break any existing users.
   cache_name:
     description: 'Cache name'
     required: false
@@ -31,8 +36,11 @@ runs:
           ${{ inputs.directories }}
         key: ${{ runner.os }}-build-${{ inputs.cache_name }}-${{ github.sha }}
     - if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-          npm install
-          npm run --if-present build
-          ${{ inputs.build }}
+      run: npm install
+      shell: bash
+    - if: steps.cache.outputs.cache-hit != 'true' && ${{ inputs.build_on_cache_fail }} == 'true'
+      run: npm run --if-present build
+      shell: bash
+    - if: steps.cache.outputs.cache-hit != 'true' && ${{ inputs.build }} != 'echo'
+      run: ${{ inputs.build }}
       shell: bash


### PR DESCRIPTION
I've used this action several times and did not know that it was also calling `npm run build`. 

The build step can increase a workflow's runtime and complexity, and I usually don't want to do that. I think it's useful, but since there was already support for `inputs.build`, I think it's unnecessary. An opt-out (since we don't want to break existing users) will help me out a lot.