### PR TITLE
docs: remove ts command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Commands:
   aegir release                      Release your code onto the world
   aegir test-dependant [repo]        Run the tests of an module that depends on this module to see if the current changes have caused a regression
   aegir test                         Test your code in different environments
-  aegir ts                           Typescript command with presets for specific tasks.
   aegir dependency-check [input...]  Run `dependency-check` cli with aegir defaults.                                                                                                                              [aliases: dep-check, dep]
   aegir lint-package-json            Lint package.json with aegir defaults.                                                                                                                                    [aliases: lint-package, lpj]
   aegir completion                   generate completion script
@@ -120,19 +119,7 @@ Check the [documentation](https://ipfs.github.io/aegir/)
 
 ## Typescript
 
-### JSDoc Typescript support
-
-```bash
-aegir ts --help
-```
-More documentation [here](https://github.com/ipfs/aegir/blob/master/md/ts-jsdoc.md)
-
-### Native Typescript support
-For native typescript add `--ts-repo` to any command.
-```bash
-aegir build --ts-repo
-aegir test --ts-repo
-```
+Aegir will detect the presence of `tsconfig.json` files and build typescript as appropriate.
 
 ## Release steps
 

--- a/md/github-actions.md
+++ b/md/github-actions.md
@@ -17,9 +17,6 @@ jobs:
     - uses: actions/checkout@v2
     - run: npm install
     - run: npx aegir lint
-    - run: npx aegir ts -p check
-    # or
-    # - uses: gozala/typescript-error-reporter-action@v1.0.8
     - run: npx aegir build
     - run: npx aegir dep-check
     - uses: ipfs/aegir/actions/bundle-size@master

--- a/md/ts-jsdoc.md
+++ b/md/ts-jsdoc.md
@@ -1,9 +1,7 @@
 # TS with JSDoc  <!-- omit in toc -->
 
-
 ## Table of Contents  <!-- omit in toc -->
 - [Getting Started](#getting-started)
-- [CLI `ts` command](#cli-ts-command)
 - [Github Action](#github-action)
 - [Installing package from a git url](#installing-package-from-a-git-url)
 - [Adding types with JSDoc](#adding-types-with-jsdoc)
@@ -19,12 +17,22 @@
 - [Must read references](#must-read-references)
 - [Resources](#resources)
 
-
 ## Getting Started
 
-Add a `tsconfig.json` to your repo:
-```bash
-aegir ts -p config > tsconfig.json
+Add a `tsconfig.json` to your repo that extends the default aegir ts config:
+
+```json
+{
+  "extends": "aegir/src/config/tsconfig.aegir.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "emitDeclarationOnly": true
+  },
+  "include": [
+    "src",
+    "test"
+  ]
+}
 ```
 
 Add types configuration to your package.json:
@@ -51,20 +59,6 @@ When a packages needs to allow type imports other than the entry point, you can 
 
 > Use this hack only if you really need it, this might change from the TS side at any time and break type checks.
 
-
-## CLI `ts` command
-
-> The `ts` command follows aegir folder conventions, source code inside `./src`, test inside `./test` and documentation inside `./docs`.
-
-Run `aegir ts --help` and check the help text. There's presets for common TS use cases.
-
-```md
-Presets:
-`check`       Runs the type checker with your local config and doesn't not emit output.
-`types`       Emits type declarations to `dist` folder.
-`docs`        Generates documentation based on type declarations to the `docs` folder.
-`config`      Prints base config to stdout.
-```
 ## Github Action
 
 To run the typechecker in the CI you can use this action https://github.com/Gozala/typescript-error-reporter-action and you will get the errors reported inline with the code.


### PR DESCRIPTION
The `aegir ts` command has been removed in favour of doing everything during `aegir build` so remove the references to it in the docs.

closes #1077