### PR TITLE
fix: publish docs by default in CI

### DIFF
--- a/src/config/user.js
+++ b/src/config/user.js
@@ -61,7 +61,7 @@ const defaults = {
   },
   // docs cmd options
   docs: {
-    publish: false,
+    publish: Boolean(process.env.CI),
     entryPoint: isTypescript ? 'src/index.ts' : 'src/index.js'
   },
   // ts cmd options


### PR DESCRIPTION
Use the CI env var to default publishing docs to true when running in CI.