### PR TITLE
fix: only add browser script tag instructions for browser modules

### DIFF
--- a/src/check-project/readme/install.js
+++ b/src/check-project/readme/install.js
@@ -2,24 +2,37 @@
  * @param {*} pkg
  */
 export const INSTALL = (pkg) => {
-  return `
-## Install
+  const nodeInstall = `
+  ## Install
 
-\`\`\`console
-$ npm i ${pkg.name}
-\`\`\`
+  \`\`\`console
+  $ npm i ${pkg.name}
+  \`\`\`
+`
+  const browserInstall = `### Browser \`<script>\` tag
 
-### Browser \`<script>\` tag
+  Loading this module through a script tag will make it's exports available as \`${nameToGlobalSymbol(pkg.name)}\` in the global namespace.
 
-Loading this module through a script tag will make it's exports available as \`${nameToGlobalSymbol(pkg.name)}\` in the global namespace.
+  \`\`\`html
+  <script src="https://unpkg.com/${pkg.name}/dist/index.min.js"></script>
+  \`\`\`
+`
+  const scripts = pkg.scripts ?? {}
 
-\`\`\`html
-<script src="https://unpkg.com/${pkg.name}/dist/index.min.js"></script>
-\`\`\`
-  `
+  // if the module tests on browsers include browser install instructions
+  if (scripts['test:chrome'] != null || scripts['test:firefox'] != null || scripts['test:browser'] != null) {
+    return nodeInstall + browserInstall
+  }
+
+  // otherwise just include node install instructions
+  return nodeInstall
 }
 
 /**
+ * Esbuild uses the module name to determine the symbol that's added to
+ * the global scope by the minified build so replicate how it determines
+ * the name in order to add it to the docs.
+ *
  * @param {string} name
  * @returns {string}
  */


### PR DESCRIPTION
If a module declares test scripts for browsers, add a block to the readme that details how to use browser script tags.