### PR TITLE
fix: generate docs on publish, control publishing from release job

### DIFF
--- a/src/check-project/check-monorepo-readme.js
+++ b/src/check-project/check-monorepo-readme.js
@@ -11,6 +11,7 @@ import { parseMarkdown, writeMarkdown } from './readme/utils.js'
 import { HEADER } from './readme/header.js'
 import { LICENSE } from './readme/license.js'
 import { STRUCTURE } from './readme/structure.js'
+import { APIDOCS } from './readme/api-docs.js'
 
 /**
  * @param {string} projectDir
@@ -109,11 +110,13 @@ export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, p
   })
 
   const license = parseMarkdown(LICENSE(pkg, repoOwner, repoName, defaultBranch))
+  const apiDocs = parseMarkdown(APIDOCS(pkg))
   const structure = parseMarkdown(STRUCTURE(projectDir, projectDirs))
 
   parsedReadme.children = [
     ...structure.children,
     ...parsedReadme.children,
+    ...apiDocs.children,
     ...license.children
   ]
 

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -61,7 +61,7 @@ const defaults = {
   },
   // docs cmd options
   docs: {
-    publish: Boolean(process.env.CI) && process.env.NODE_ENV !== 'test',
+    publish: Boolean(process.env.CI),
     entryPoint: isTypescript ? 'src/index.ts' : 'src/index.js',
     message: 'docs: update documentation [skip ci]',
     user: 'aegir[bot]',

--- a/src/release.js
+++ b/src/release.js
@@ -2,7 +2,7 @@
 
 import Listr from 'listr'
 import { execa } from 'execa'
-import { isMonorepoProject } from './utils.js'
+import { isMonorepoProject, hasDocs } from './utils.js'
 import fs from 'fs-extra'
 import path from 'path'
 import glob from 'it-glob'
@@ -16,9 +16,10 @@ import { calculateSiblingVersion } from './check-project/utils.js'
 
 const tasks = new Listr([
   {
-    title: 'docs',
+    title: 'generate typedoc urls',
+    enabled: () => hasDocs,
     task: async () => {
-      await execa('npm', ['run', 'docs', '--if-present'], {
+      await execa('npm', ['run', 'docs', '--if-present', '--', '--publish', 'false'], {
         stdio: 'inherit'
       })
     }
@@ -118,6 +119,15 @@ const tasks = new Listr([
       console.info('Push to remote') // eslint-disable-line no-console
       await execa('git', ['push'], {
         cwd: rootDir
+      })
+    }
+  },
+  {
+    title: 'publish documentation',
+    enabled: () => hasDocs,
+    task: async () => {
+      await execa('npm', ['run', 'docs', '--if-present'], {
+        stdio: 'inherit'
       })
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -250,6 +250,7 @@ export const hasMain = Boolean(pkg.main)
 export const hasIndexTs = hasFile('src/index.ts')
 export const hasIndexJs = hasFile('src/index.js')
 export const isMonorepoParent = Boolean(pkg.workspaces)
+export const hasDocs = Boolean(pkg.scripts?.docs)
 
 // our project types:
 

--- a/test/docs.js
+++ b/test/docs.js
@@ -21,7 +21,7 @@ describe('docs', () => {
     it('should document an esm project', async function () {
       this.timeout(120 * 1000) // slow ci is slow
 
-      await execa(bin, ['docs'], {
+      await execa(bin, ['docs', '--publish', 'false'], {
         cwd: projectDir
       })
 
@@ -48,7 +48,7 @@ describe('docs', () => {
       await execa(bin, ['build'], {
         cwd: projectDir
       })
-      await execa(bin, ['docs'], {
+      await execa(bin, ['docs', '--publish', 'false'], {
         cwd: projectDir
       })
 


### PR DESCRIPTION
CI has `NODE_ENV=test` so docs release is skipped, control publish setting from release job instead.