### PR TITLE
fix: disable package-lock.json in monorepos

### DIFF
--- a/src/check-project/check-monorepo-files.js
+++ b/src/check-project/check-monorepo-files.js
@@ -20,13 +20,17 @@ export async function checkMonorepoFiles (projectDir) {
   let defaultLernaContent = fs.readFileSync(path.join(__dirname, 'files/lerna.json'), {
     encoding: 'utf-8'
   })
-  defaultLernaContent = defaultLernaContent.replace(/\$lerna-version/g, pkg.dependencies.lerna.replace(/\^/, ''))
 
-  // ensure npm workspaces/lerna packages are in sync
+  // ensure lerna version is in sync
   const lernaConfig = JSON.parse(defaultLernaContent)
-  lernaConfig.packages = pkg.workspaces
+  lernaConfig.lerna = pkg.dependencies.lerna.replace(/\^/, '')
 
   defaultLernaContent = JSON.stringify(lernaConfig, null, 2)
 
   await ensureFileHasContents(projectDir, 'lerna.json', defaultLernaContent)
+
+  // disable package-lock.json in monorepos until https://github.com/semantic-release/github/pull/487 is merged
+  await ensureFileHasContents(projectDir, '.npmrc', fs.readFileSync(path.join(__dirname, 'files/npmrc'), {
+    encoding: 'utf-8'
+  }))
 }

--- a/src/check-project/check-monorepo-readme.js
+++ b/src/check-project/check-monorepo-readme.js
@@ -59,6 +59,7 @@ export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, p
 
   let structureIndex = -1
   let tocIndex = -1
+  let apiDocsIndex = -1
   let licenseFound = false
 
   file.children.forEach((child, index) => {
@@ -98,6 +99,17 @@ export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, p
 
     if (structureIndex !== -1 && index === structureIndex + 1) {
       // skip structure
+      return
+    }
+
+    if (child.type === 'heading' && rendered.includes('api docs')) {
+      // skip api docs header
+      apiDocsIndex = index
+      return
+    }
+
+    if (apiDocsIndex !== -1 && index === apiDocsIndex + 1) {
+      // skip api docs link
       return
     }
 

--- a/src/check-project/check-readme.js
+++ b/src/check-project/check-readme.js
@@ -58,6 +58,7 @@ export async function checkReadme (projectDir, repoUrl, defaultBranch) {
 
   let tocIndex = -1
   let installIndex = -1
+  let apiDocsIndex = -1
   let licenseFound = false
 
   /** @type {import('mdast').Content[]} */
@@ -110,6 +111,17 @@ export async function checkReadme (projectDir, repoUrl, defaultBranch) {
 
     if (rendered.includes('loading this module through a script tag') || rendered.includes('<script src="https://unpkg.com')) {
       // skip browser install instructions
+      return
+    }
+
+    if (child.type === 'heading' && rendered.includes('api docs')) {
+      // skip api docs header
+      apiDocsIndex = index
+      return
+    }
+
+    if (apiDocsIndex !== -1 && index === apiDocsIndex + 1) {
+      // skip api docs link
       return
     }
 

--- a/src/check-project/files/npmrc
+++ b/src/check-project/files/npmrc
@@ -1,0 +1,2 @@
+; package-lock with tarball deps breaks lerna/nx - remove when https://github.com/semantic-release/github/pull/487 is merged
+package-lock=false

--- a/src/docs.js
+++ b/src/docs.js
@@ -146,7 +146,7 @@ const publishDocs = async (config) => {
 const tasks = new Listr(
   [
     {
-      title: 'Clean ./docs',
+      title: 'Clean output dir',
       /**
        * @param {GlobalOptions & DocsOptions} ctx
        */
@@ -165,7 +165,7 @@ const tasks = new Listr(
     {
       title: 'Publish to GitHub Pages',
       task: (ctx) => publishDocs(ctx),
-      enabled: (ctx) => ctx.publish && hasTsconfig
+      enabled: (ctx) => ctx.publish
     }
   ],
   {


### PR DESCRIPTION
nx trips over the tarball dep we have on `@semantic-release/github` when it tries to parse project deps from the `package-lock.json` in CI so disable lockfiles in monorepos.

This will no longer be necessary when https://github.com/semantic-release/github/pull/487 is merged.