### PR TITLE
fix: only use absolute path of url mapping to find project context

### DIFF
--- a/src/docs/type-indexer-plugin.cjs
+++ b/src/docs/type-indexer-plugin.cjs
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const { RendererEvent } = require('typedoc')
+const path = require('path')
 
 /**
  * The types of models we want to store documentation URLs for
@@ -133,10 +134,10 @@ function findContext (mapping, isMonorepo) {
     // remove last path segment
     absolutePathSegments.pop()
 
-    const manifestPath = `${absolutePathSegments.join('/')}/package.json`
+    let manifestPath = makeAbsolute(path.join(...absolutePathSegments, 'package.json'))
 
     /** @type {string | undefined} */
-    let outputDir = `${isMonorepo ? `/${absolutePathSegments.join('/')}` : process.cwd()}/dist`
+    let outputDir = makeAbsolute(path.join(...(isMonorepo ? absolutePathSegments : process.cwd().split('/')), 'dist'))
 
     // this can occur when a symbol from a dependency is exported, if this is
     // the case do not try to write a `typedoc-urls.json` file
@@ -188,4 +189,19 @@ function loadManifest (Application, context) {
     typedocs: {},
     outputDir: context.outputDir
   }
+}
+
+/**
+ * Make a path absolute
+ *
+ * @param {string} p
+ * @returns {string}
+ */
+function makeAbsolute (p) {
+  // on windows it is already absolute
+  if (!p.startsWith('/') && process.platform !== 'win32') {
+    return `/${p}`
+  }
+
+  return p
 }

--- a/src/docs/type-indexer-plugin.cjs
+++ b/src/docs/type-indexer-plugin.cjs
@@ -113,7 +113,8 @@ module.exports = {
  */
 
 /**
- * Return project details for the passed UrlMapping
+ * For a given UrlMapping, find the nearest package.json file
+ * and work out if a `typedoc-urls.json` should be generated.
  *
  * @param {import("typedoc/dist/lib/output/models/UrlMapping").UrlMapping} mapping
  * @param {boolean} isMonorepo

--- a/test/docs.js
+++ b/test/docs.js
@@ -61,4 +61,30 @@ describe('docs', () => {
       })
     })
   })
+
+  describe('monorepo project', () => {
+    let projectDir = ''
+
+    before(async () => {
+      projectDir = await setUpProject('a-monorepo')
+    })
+
+    it('should document a monorepo project', async function () {
+      this.timeout(120 * 1000) // slow ci is slow
+
+      await execa(bin, ['docs', '--publish', 'false'], {
+        cwd: projectDir
+      })
+
+      expect(fs.existsSync(join(projectDir, '.docs'))).to.be.true()
+
+      const module = await import(`file://${projectDir}/packages/a-workspace-project/src/index.js`)
+      const exports = [...Object.keys(module), 'AnExportedInterface', 'ExportedButNotInExports']
+      const typedocUrls = await fs.readJSON(join(projectDir, 'packages/a-workspace-project/dist', 'typedoc-urls.json'))
+
+      exports.forEach(key => {
+        expect(typedocUrls).to.have.property(key)
+      })
+    })
+  })
 })

--- a/test/fixtures/projects/a-monorepo/package.json
+++ b/test/fixtures/projects/a-monorepo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "a-monorepo",
+  "version": "1.0.0",
+  "description": "",
+  "homepage": "https://github.com/ipfs/aegir#readme",
+  "scripts": {
+    "docs": "aegir docs"
+  },
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/test/fixtures/projects/a-monorepo/packages/a-workspace-project/package.json
+++ b/test/fixtures/projects/a-monorepo/packages/a-workspace-project/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "a-workspace-project",
+  "version": "1.0.0",
+  "description": "",
+  "homepage": "https://github.com/ipfs/aegir#readme",
+  "exports": {
+    ".": {
+      "import": "./src/index.js"
+    }
+  },
+  "type": "module",
+  "author": "",
+  "license": "ISC",
+  "typedoc": {
+    "entryPoint": "./src/index.js"
+  }
+}

--- a/test/fixtures/projects/a-monorepo/packages/a-workspace-project/src/index.js
+++ b/test/fixtures/projects/a-monorepo/packages/a-workspace-project/src/index.js
@@ -1,0 +1,16 @@
+/**
+ * @typedef {import('./types').ExportedButNotInExports} ExportedButNotInExports
+ */
+
+/**
+ * @typedef {object} AnExportedInterface
+ * @property {() => void} AnExportedInterface.aMethod
+ */
+
+export const useHerp = () => {
+
+}
+
+export const useDerp = () => {
+
+}

--- a/test/fixtures/projects/a-monorepo/packages/a-workspace-project/src/types.ts
+++ b/test/fixtures/projects/a-monorepo/packages/a-workspace-project/src/types.ts
@@ -1,0 +1,4 @@
+
+export interface ExportedButNotInExports {
+  aMethod: () => void
+}

--- a/test/fixtures/projects/a-monorepo/packages/a-workspace-project/tsconfig.json
+++ b/test/fixtures/projects/a-monorepo/packages/a-workspace-project/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+      "strict": true,
+      // project options
+      "outDir": "dist",
+      "allowJs": true,
+      "checkJs": true,
+      "target": "ES2020",
+      "module": "ES2020",
+      "lib": ["ES2021", "ES2021.Promise", "ES2021.String", "ES2020.BigInt", "DOM", "DOM.Iterable"],
+      "noEmit": false,
+      "noEmitOnError": true,
+      "emitDeclarationOnly": true,
+      "declaration": true,
+      "declarationMap": true,
+      "incremental": true,
+      "composite": true,
+      "isolatedModules": true,
+      "removeComments": false,
+      "sourceMap": true,
+      // module resolution
+      "esModuleInterop": true,
+      "moduleResolution": "node",
+      // linter checks
+      "noImplicitReturns": false,
+      "noFallthroughCasesInSwitch": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": false,
+      // advanced
+      "importsNotUsedAsValues": "error",
+      "forceConsistentCasingInFileNames": true,
+      "skipLibCheck": true,
+      "stripInternal": true,
+      "resolveJsonModule": true
+  },
+  "include": [
+      "src"
+  ]
+}

--- a/test/fixtures/projects/a-monorepo/packages/another-workspace-project/package.json
+++ b/test/fixtures/projects/a-monorepo/packages/another-workspace-project/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "another-workspace-project",
+  "version": "1.0.0",
+  "description": "",
+  "homepage": "https://github.com/ipfs/aegir#readme",
+  "exports": {
+    ".": {
+      "import": "./src/index.js"
+    }
+  },
+  "type": "module",
+  "author": "",
+  "license": "ISC",
+  "typedoc": {
+    "entryPoint": "./src/index.js"
+  }
+}

--- a/test/fixtures/projects/a-monorepo/packages/another-workspace-project/src/index.js
+++ b/test/fixtures/projects/a-monorepo/packages/another-workspace-project/src/index.js
@@ -1,0 +1,16 @@
+/**
+ * @typedef {import('./types').ExportedButNotInExports} ExportedButNotInExports
+ */
+
+/**
+ * @typedef {object} AnExportedInterface
+ * @property {() => void} AnExportedInterface.aMethod
+ */
+
+export const useHerp = () => {
+
+}
+
+export const useDerp = () => {
+
+}

--- a/test/fixtures/projects/a-monorepo/packages/another-workspace-project/src/types.ts
+++ b/test/fixtures/projects/a-monorepo/packages/another-workspace-project/src/types.ts
@@ -1,0 +1,4 @@
+
+export interface ExportedButNotInExports {
+  aMethod: () => void
+}

--- a/test/fixtures/projects/a-monorepo/packages/another-workspace-project/tsconfig.json
+++ b/test/fixtures/projects/a-monorepo/packages/another-workspace-project/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+      "strict": true,
+      // project options
+      "outDir": "dist",
+      "allowJs": true,
+      "checkJs": true,
+      "target": "ES2020",
+      "module": "ES2020",
+      "lib": ["ES2021", "ES2021.Promise", "ES2021.String", "ES2020.BigInt", "DOM", "DOM.Iterable"],
+      "noEmit": false,
+      "noEmitOnError": true,
+      "emitDeclarationOnly": true,
+      "declaration": true,
+      "declarationMap": true,
+      "incremental": true,
+      "composite": true,
+      "isolatedModules": true,
+      "removeComments": false,
+      "sourceMap": true,
+      // module resolution
+      "esModuleInterop": true,
+      "moduleResolution": "node",
+      // linter checks
+      "noImplicitReturns": false,
+      "noFallthroughCasesInSwitch": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": false,
+      // advanced
+      "importsNotUsedAsValues": "error",
+      "forceConsistentCasingInFileNames": true,
+      "skipLibCheck": true,
+      "stripInternal": true,
+      "resolveJsonModule": true
+  },
+  "include": [
+      "src"
+  ]
+}


### PR DESCRIPTION
In a monorepo sometimes the packages folder name is prepended to the url mapping source file name and sometimes it isn't so ignore that and just use the absolute path to determine the package.json for a given file.