### PR TITLE
fix: link to api docs from monorepo child projects

### DIFF
--- a/src/check-project/check-readme.js
+++ b/src/check-project/check-readme.js
@@ -17,8 +17,9 @@ import { APIDOCS } from './readme/api-docs.js'
  * @param {string} projectDir
  * @param {string} repoUrl
  * @param {string} defaultBranch
+ * @param {any} [rootManifest]
  */
-export async function checkReadme (projectDir, repoUrl, defaultBranch) {
+export async function checkReadme (projectDir, repoUrl, defaultBranch, rootManifest) {
   const repoParts = repoUrl.split('/')
   const repoName = repoParts.pop()
   const repoOwner = repoParts.pop()
@@ -139,7 +140,7 @@ export async function checkReadme (projectDir, repoUrl, defaultBranch) {
   })
 
   const installation = parseMarkdown(INSTALL(pkg))
-  const apiDocs = parseMarkdown(APIDOCS(pkg))
+  const apiDocs = parseMarkdown(APIDOCS(pkg, rootManifest))
   const license = parseMarkdown(LICENSE(pkg, repoOwner, repoName, defaultBranch))
 
   parsedReadme.children = [

--- a/src/check-project/index.js
+++ b/src/check-project/index.js
@@ -112,7 +112,7 @@ async function processMonorepo (projectDir, manifest, branchName, repoUrl) {
 
       console.info('Found monorepo project', pkg.name)
 
-      await processModule(subProjectDir, pkg, branchName, repoUrl, homePage)
+      await processModule(subProjectDir, pkg, branchName, repoUrl, homePage, manifest)
 
       projectDirs.push(subProjectDir)
     }
@@ -305,8 +305,9 @@ function isAegirProject (manifest) {
  * @param {string} branchName
  * @param {string} repoUrl
  * @param {string} homePage
+ * @param {any} [rootManifest]
  */
-async function processModule (projectDir, manifest, branchName, repoUrl, homePage = repoUrl) {
+async function processModule (projectDir, manifest, branchName, repoUrl, homePage = repoUrl, rootManifest) {
   if (!isAegirProject(manifest) && manifest.name !== 'aegir') {
     throw new Error(`"${projectDir}" is not an aegir project`)
   }
@@ -382,7 +383,7 @@ async function processModule (projectDir, manifest, branchName, repoUrl, homePag
 
   await ensureFileHasContents(projectDir, 'package.json', JSON.stringify(proposedManifest, null, 2))
   await checkLicenseFiles(projectDir)
-  await checkReadme(projectDir, repoUrl, branchName)
+  await checkReadme(projectDir, repoUrl, branchName, rootManifest)
 }
 
 export default new Listr([

--- a/src/check-project/readme/api-docs.js
+++ b/src/check-project/readme/api-docs.js
@@ -1,12 +1,15 @@
 /**
  * @param {*} pkg
+ * @param {*} [parentManifest]
  */
-export const APIDOCS = (pkg) => {
-  if (pkg.scripts.docs == null) {
+export const APIDOCS = (pkg, parentManifest) => {
+  const scripts = parentManifest?.scripts ?? pkg.scripts ?? {}
+
+  if (scripts.docs == null) {
     return ''
   }
 
-  const ghPages = parseGhPagesUrl(pkg)
+  const ghPages = parseGhPagesUrl(pkg, parentManifest)
 
   return `
 ## API Docs
@@ -20,14 +23,23 @@ export const APIDOCS = (pkg) => {
  * url for the documentation website.
  *
  * @param {*} pkg
+ * @param {*} [parentManifest]
  * @returns {string}
  */
-function parseGhPagesUrl (pkg) {
+function parseGhPagesUrl (pkg, parentManifest) {
   try {
     // find gh-pages url
     const homepage = new URL(pkg.homepage)
     const [orgName, moduleName] = homepage.pathname.split('/').filter(Boolean)
-    return `https://${orgName}.github.io/${moduleName}`
+
+    let ghPages = `https://${orgName}.github.io/${moduleName}`
+
+    if (parentManifest != null) {
+      // we are a submodule of a monorepo so link directly to the module page
+      ghPages += `/modules/${pkg.name.toLowerCase().replace(/[^a-z0-9]/g, '_')}.html`
+    }
+
+    return ghPages
   } catch (/** @type {any} **/ err) {
     throw new Error(`Could not detect gh-pages url - does the package.json have a valid homepage key? - ${err.stack}`)
   }


### PR DESCRIPTION
Link directly to the module pages of monorepo child project api docs.