### PR TITLE
fix: exclude node_modules from docs

### DIFF
--- a/src/docs.js
+++ b/src/docs.js
@@ -44,6 +44,8 @@ const docs = async (ctx, task) => {
       ctx.directory,
       '--hideGenerator',
       '--includeVersion',
+      '--exclude',
+      '**/node_modules/**',
       '--gitRevision',
       'master',
       '--plugin',

--- a/src/docs/type-indexer-plugin.cjs
+++ b/src/docs/type-indexer-plugin.cjs
@@ -81,6 +81,7 @@ function load (Application) {
         typedocs[context.manifestPath] = details
       }
 
+      // cannot differentiate between types with duplicate names in the same module https://github.com/TypeStrong/typedoc/issues/2125
       if (typedocs[context.manifestPath].typedocs[urlMapping.model.originalName] != null) {
         Application.logger.warn(`Duplicate exported type name ${urlMapping.model.originalName} defined in ${urlMapping.model.sources[0].fullFileName}`)
       } else {

--- a/src/docs/type-indexer-plugin.cjs
+++ b/src/docs/type-indexer-plugin.cjs
@@ -81,8 +81,12 @@ function load (Application) {
         typedocs[context.manifestPath] = details
       }
 
-      // store reference to generate doc url
-      typedocs[context.manifestPath].typedocs[urlMapping.model.originalName] = `${ghPages}${urlMapping.url}`
+      if (typedocs[context.manifestPath].typedocs[urlMapping.model.originalName] != null) {
+        Application.logger.warn(`Duplicate exported type name ${urlMapping.model.originalName} defined in ${urlMapping.model.sources[0].fullFileName}`)
+      } else {
+        // store reference to generate doc url
+        typedocs[context.manifestPath].typedocs[urlMapping.model.originalName] = `${ghPages}${urlMapping.url}`
+      }
     }
 
     Object.keys(typedocs).forEach(manifestPath => {

--- a/src/docs/unknown-symbol-resolver-plugin.cjs
+++ b/src/docs/unknown-symbol-resolver-plugin.cjs
@@ -5,13 +5,15 @@ const knownSymbols = {
   '@types/chai': {
     'Chai.ChaiStatic': 'https://www.chaijs.com/api/',
     'Chai.Assertion': 'https://www.chaijs.com/api/assert/'
+  },
+  '@types/node': {
+    'EventEmitter': 'https://nodejs.org/dist/latest-v19.x/docs/api/events.html#class-eventemitter'
   }
 }
 
 // these are handled by the plugin typedoc-plugin-mdn-links
 const ignoreModules = [
-  'typescript',
-  '@types/node'
+  'typescript'
 ]
 
 /**

--- a/src/docs/unknown-symbol-resolver-plugin.cjs
+++ b/src/docs/unknown-symbol-resolver-plugin.cjs
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 
 /** @type {Record<string, Record<string, string>>} */
 const knownSymbols = {
@@ -7,7 +8,13 @@ const knownSymbols = {
     'Chai.Assertion': 'https://www.chaijs.com/api/assert/'
   },
   '@types/node': {
-    'EventEmitter': 'https://nodejs.org/dist/latest-v19.x/docs/api/events.html#class-eventemitter'
+    'EventEmitter': 'https://nodejs.org/dist/latest-v19.x/docs/api/events.html#class-eventemitter',
+    'global.NodeJS.ReadStream': 'https://nodejs.org/dist/latest-v19.x/docs/api/tty.html#class-ttyreadstream',
+    'global.NodeJS.WriteStream': 'https://nodejs.org/dist/latest-v19.x/docs/api/tty.html#class-ttywritestream',
+    'internal.Duplex': 'https://nodejs.org/dist/latest-v19.x/docs/api/stream.html#class-streamduplex',
+    'internal.Readable': 'https://nodejs.org/dist/latest-v19.x/docs/api/stream.html#class-streamreadable',
+    'internal.Transform': 'https://nodejs.org/dist/latest-v19.x/docs/api/stream.html#class-streamtransform',
+    'internal.Writable': 'https://nodejs.org/dist/latest-v19.x/docs/api/stream.html#class-streamwritable',
   }
 }
 
@@ -64,33 +71,16 @@ module.exports = {
  * @param {string} moduleName
  */
 function loadTypedocUrls (moduleName) {
-  try {
-    return require(`${moduleName}/dist/typedoc-urls.json`)
-  } catch (/** @type {any} */ err) {
-    if (err.message.includes('Cannot find module')) {
-      // typedoc-urls did not exist in module with main field
-      return {}
+  const parts = process.cwd().split('/')
+
+  while (parts.length > 0) {
+    const typedocUrls = path.join(...parts, 'node_modules', moduleName, 'dist', 'typedoc-urls.json')
+
+    if (fs.existsSync(typedocUrls)) {
+      return JSON.parse(fs.readFileSync(typedocUrls, 'utf-8'))
     }
 
-    if (err.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
-      throw err
-    }
-
-    // try to load manifest from module with only exports map
-    const match = err.message.match(/ in (.*)$/)
-
-    if (match.length > 1) {
-      const manifestPath = match[1].trim()
-      const docUrlsPath = manifestPath.replace('package.json', 'dist/typedoc-urls.json')
-
-      if (!fs.existsSync(docUrlsPath)) {
-        return {}
-      }
-
-      return JSON.parse(fs.readFileSync(docUrlsPath, 'utf-8'))
-    }
-
-    throw err
+    parts.pop()
   }
 }
 

--- a/test/fixtures/projects/a-ts-project/src/index.ts
+++ b/test/fixtures/projects/a-ts-project/src/index.ts
@@ -1,6 +1,7 @@
 import herp from 'a-cjs-dep'
 import derp from 'an-esm-dep'
 import type { UsedButNotExported } from './a-module.js'
+import type { EventEmitter } from 'node:events'
 
 export const useHerp = () => {
   herp()
@@ -17,5 +18,9 @@ export interface AnExportedInterface {
 export type { ExportedButNotInExports } from './a-module.js'
 
 export interface UsesInternalType extends UsedButNotExported {
+
+}
+
+export interface ExtendsEmitter extends EventEmitter {
 
 }


### PR DESCRIPTION
To avoid generating docs for `@types/node` and typescript internals,
exclude documenting types from `node_modules`.