### PR TITLE
feat: add run and exec commands for executing commands in monorepo packages

### DIFF
--- a/src/cmds/exec.js
+++ b/src/cmds/exec.js
@@ -1,0 +1,39 @@
+import { loadUserConfig } from '../config/user.js'
+import execCmd from '../exec.js'
+
+/**
+ * @typedef {import("yargs").Argv} Argv
+ * @typedef {import("yargs").Arguments} Arguments
+ * @typedef {import("yargs").CommandModule} CommandModule
+ */
+
+const EPILOG = ''
+
+/** @type {CommandModule} */
+export default {
+  command: 'exec',
+  describe: 'Run a command in each project of a monorepo',
+  /**
+   * @param {Argv} yargs
+   */
+  builder: async (yargs) => {
+    const userConfig = await loadUserConfig()
+
+    return yargs
+      .epilog(EPILOG)
+      .options({
+        bail: {
+          type: 'boolean',
+          describe: '',
+          default: userConfig.build.bundle
+        }
+      })
+  },
+
+  /**
+   * @param {any} argv
+   */
+  async handler (argv) {
+    await execCmd.run(argv)
+  }
+}

--- a/src/cmds/exec.js
+++ b/src/cmds/exec.js
@@ -7,11 +7,14 @@ import execCmd from '../exec.js'
  * @typedef {import("yargs").CommandModule} CommandModule
  */
 
-const EPILOG = ''
+const EPILOG = `Example:
+
+$ aegir exec david -- update
+`
 
 /** @type {CommandModule} */
 export default {
-  command: 'exec',
+  command: 'exec <command>',
   describe: 'Run a command in each project of a monorepo',
   /**
    * @param {Argv} yargs

--- a/src/cmds/run.js
+++ b/src/cmds/run.js
@@ -1,0 +1,42 @@
+import { loadUserConfig } from '../config/user.js'
+import runCmd from '../run.js'
+
+/**
+ * @typedef {import("yargs").Argv} Argv
+ * @typedef {import("yargs").Arguments} Arguments
+ * @typedef {import("yargs").CommandModule} CommandModule
+ */
+
+const EPILOG = ''
+
+/** @type {CommandModule} */
+export default {
+  command: 'run <scripts..>',
+  describe: 'Run an npm script in each project of a monorepo',
+  /**
+   * @param {Argv} yargs
+   */
+  builder: async (yargs) => {
+    const userConfig = await loadUserConfig()
+
+    return yargs
+      .epilog(EPILOG)
+      .options({
+        bail: {
+          type: 'boolean',
+          describe: '',
+          default: userConfig.build.bundle
+        }
+      })
+      .positional('script', {
+        array: true
+      })
+  },
+
+  /**
+   * @param {any} argv
+   */
+  async handler (argv) {
+    await runCmd.run(argv)
+  }
+}

--- a/src/cmds/run.js
+++ b/src/cmds/run.js
@@ -7,12 +7,15 @@ import runCmd from '../run.js'
  * @typedef {import("yargs").CommandModule} CommandModule
  */
 
-const EPILOG = ''
+const EPILOG = `Example:
+
+$ aegir run clean build
+`
 
 /** @type {CommandModule} */
 export default {
   command: 'run <scripts..>',
-  describe: 'Run an npm script in each project of a monorepo',
+  describe: 'Run one or more npm scripts in each project of a monorepo',
   /**
    * @param {Argv} yargs
    */

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -131,6 +131,12 @@ const defaults = {
       '@types/*',
       'aegir'
     ]
+  },
+  exec: {
+    bail: true
+  },
+  run: {
+    bail: true
   }
 }
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -9,22 +9,17 @@ import kleur from 'kleur'
 
 export default {
   /**
-   * @param {GlobalOptions & ExecOptions} ctx
+   * @param {GlobalOptions & ExecOptions & { command: string }} ctx
    */
   async run (ctx) {
     const forwardOptions = ctx['--'] ? ctx['--'] : []
-    const command = forwardOptions.shift()
-
-    if (command == null) {
-      throw new Error('Please specify a command as forward args')
-    }
 
     await everyMonorepoProject(process.cwd(), async (project) => {
       console.info('') // eslint-disable-line no-console
-      console.info(kleur.grey(`${project.manifest.name} > ${command} ${forwardOptions.join(' ')}`)) // eslint-disable-line no-console
+      console.info(kleur.grey(`${project.manifest.name} > ${ctx.command} ${forwardOptions.join(' ')}`)) // eslint-disable-line no-console
 
       try {
-        await execa(command, forwardOptions, {
+        await execa(ctx.command, forwardOptions, {
           cwd: project.dir,
           stderr: 'inherit',
           stdout: 'inherit'

--- a/src/exec.js
+++ b/src/exec.js
@@ -1,0 +1,41 @@
+import { everyMonorepoProject } from './utils.js'
+import { execa } from 'execa'
+import kleur from 'kleur'
+
+/**
+ * @typedef {import("./types").GlobalOptions} GlobalOptions
+ * @typedef {import("./types").ExecOptions} ExecOptions
+ */
+
+export default {
+  /**
+   * @param {GlobalOptions & ExecOptions} ctx
+   */
+  async run (ctx) {
+    const forwardOptions = ctx['--'] ? ctx['--'] : []
+    const command = forwardOptions.shift()
+
+    if (command == null) {
+      throw new Error('Please specify a command as forward args')
+    }
+
+    await everyMonorepoProject(process.cwd(), async (project) => {
+      console.info('') // eslint-disable-line no-console
+      console.info(kleur.grey(`${project.manifest.name} > ${command} ${forwardOptions.join(' ')}`)) // eslint-disable-line no-console
+
+      try {
+        await execa(command, forwardOptions, {
+          cwd: project.dir,
+          stderr: 'inherit',
+          stdout: 'inherit'
+        })
+      } catch (/** @type {any} */ err) {
+        if (ctx.bail !== false) {
+          throw err
+        }
+
+        console.info(kleur.red(err.stack)) // eslint-disable-line no-console
+      }
+    })
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ import releaseCmd from './cmds/release.js'
 import testDependantCmd from './cmds/test-dependant.js'
 import testCmd from './cmds/test.js'
 import docsCmd from './cmds/docs.js'
+import execCmd from './cmds/exec.js'
+import runCmd from './cmds/run.js'
 
 /**
  * @typedef {import('./types').BuildOptions} BuildOptions
@@ -89,6 +91,8 @@ async function main () {
   res.command(releaseCmd)
   res.command(testDependantCmd)
   res.command(testCmd)
+  res.command(execCmd)
+  res.command(runCmd)
 
   try {
     await res.parse()

--- a/src/run.js
+++ b/src/run.js
@@ -1,0 +1,48 @@
+import { everyMonorepoProject } from './utils.js'
+import { execa } from 'execa'
+import kleur from 'kleur'
+
+/**
+ * @typedef {import("./types").GlobalOptions} GlobalOptions
+ * @typedef {import("./types").RunOptions} RunOptions
+ */
+
+export default {
+  /**
+   * @param {GlobalOptions & RunOptions & { scripts: string[] }} ctx
+   */
+  async run (ctx) {
+    const scripts = ctx.scripts
+
+    if (scripts == null || scripts.length === 0) {
+      throw new Error('Please specify a script')
+    }
+
+    const forwardArgs = ctx['--'] == null ? [] : ['--', ...ctx['--']]
+
+    await everyMonorepoProject(process.cwd(), async (project) => {
+      for (const script of scripts) {
+        if (project.manifest.scripts[script] == null) {
+          continue
+        }
+
+        console.info('') // eslint-disable-line no-console
+        console.info(kleur.grey(`${project.manifest.name} > npm run ${script} ${forwardArgs.join(' ')}`)) // eslint-disable-line no-console
+
+        try {
+          await execa('npm', ['run', script, ...forwardArgs], {
+            cwd: project.dir,
+            stderr: 'inherit',
+            stdout: 'inherit'
+          })
+        } catch (/** @type {any} */ err) {
+          if (ctx.bail !== false) {
+            throw err
+          }
+
+          console.info(kleur.red(err.stack)) // eslint-disable-line no-console
+        }
+      }
+    })
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,14 @@ interface Options extends GlobalOptions {
    * Options for the `dependency-check` command
    */
   dependencyCheck: DependencyCheckOptions
+  /**
+   * Options for the `exec` command
+   */
+  exec: ExecOptions
+  /**
+   * Options for the `run` command
+   */
+  run: RunOptions
 }
 
 /**
@@ -309,6 +317,20 @@ interface DependencyCheckOptions {
   productionInput: string[]
 }
 
+interface ExecOptions {
+  /**
+   * If false, the command will continue to be run in other packages
+   */
+  bail?: boolean
+}
+
+interface RunOptions {
+  /**
+   * If false, the command will continue to be run in other packages
+   */
+  bail?: boolean
+}
+
 export type {
   PartialOptions,
   Options,
@@ -319,5 +341,7 @@ export type {
   LintOptions,
   TestOptions,
   ReleaseOptions,
-  DependencyCheckOptions
+  DependencyCheckOptions,
+  ExecOptions,
+  RunOptions
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,6 +20,7 @@ import envPaths from 'env-paths'
 import lockfile from 'proper-lockfile'
 import { fileURLToPath } from 'url'
 import Listr from 'listr'
+import glob from 'it-glob'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const EnvPaths = envPaths('aegir', { suffix: '' })
@@ -299,4 +300,83 @@ export function findBinary (bin) {
 
   // let shell work it out or error
   return bin
+}
+
+/**
+ * @typedef {object} Project
+ * @property {any} manifest
+ * @property {string} dir
+ * @property {string[]} siblingDependencies
+ * @property {string[]} dependencies
+ * @property {boolean} run
+ */
+
+/**
+ * @param {string} projectDir
+ * @param {(project: Project) => Promise<void>} fn
+ */
+export async function everyMonorepoProject (projectDir, fn) {
+  const manifest = fs.readJSONSync(path.join(projectDir, 'package.json'))
+  const workspaces = manifest.workspaces
+
+  if (!workspaces || !Array.isArray(workspaces)) {
+    throw new Error('No monorepo workspaces found')
+  }
+
+  /** @type {Record<string, Project>} */
+  const projects = {}
+
+  for (const workspace of workspaces) {
+    for await (const subProjectDir of glob('.', workspace, {
+      cwd: projectDir,
+      absolute: true
+    })) {
+      const pkg = fs.readJSONSync(path.join(subProjectDir, 'package.json'))
+
+      projects[pkg.name] = {
+        manifest: pkg,
+        dir: subProjectDir,
+        siblingDependencies: [],
+        run: false,
+        dependencies: [
+          ...Object.keys(pkg.dependencies ?? {}),
+          ...Object.keys(pkg.devDependencies ?? {}),
+          ...Object.keys(pkg.optionalDependencies ?? {}),
+          ...Object.keys(pkg.peerDependencies ?? {})
+        ]
+      }
+    }
+  }
+
+  for (const project of Object.values(projects)) {
+    for (const dep of project.dependencies) {
+      if (projects[dep] != null) {
+        project.siblingDependencies.push(dep)
+      }
+    }
+  }
+
+  /**
+   * @param {Project} project
+   */
+  async function run (project) {
+    if (project.run) {
+      return
+    }
+
+    for (const siblingDep of project.siblingDependencies) {
+      await run(projects[siblingDep])
+    }
+
+    if (project.run) {
+      return
+    }
+
+    project.run = true
+    await fn(project)
+  }
+
+  for (const project of Object.values(projects)) {
+    await run(project)
+  }
 }


### PR DESCRIPTION
The only reason we keep lerna about is for running scripts and commands in monorepo packages.  Unlike npm it's clever enough to figure out the dependency graph of monorepo packages before running the commands or scripts in order to ensure that they've been run in a modules dependencies before being run in that module.

This PR adds two new commands to aegir that do the same thing:

1. exec - this will run a binary command in each monorepo package
2. run - this will run one or more npm scripts in each package

E.g. run `ls` in every package

```console
$ aegir exec ls
```

E.g. clean and build every package

```console
$ aegir run clean build
```

Both commands support forwarding args:

E.g. lint every package, fixing errors

```console
$ aegir run lint -- --fix
```