### PR TITLE
fix: update actions/cache

### DIFF
--- a/actions/cache-node-modules/action.yml
+++ b/actions/cache-node-modules/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     # Windows I/O is so slow it's faster to just install the deps every time
     - if: ${{ runner.os != 'Windows' }}
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache
       with:
         path: |


### PR DESCRIPTION
Update actions/cache to v3 to use node 16 instead of node 12 which is now deprecated by GitHub.