### PR TITLE
fix: do not create npmrc for monorepos

### DIFF
--- a/src/check-project/check-monorepo-files.js
+++ b/src/check-project/check-monorepo-files.js
@@ -1,22 +1,11 @@
 /* eslint-disable no-console */
 
-import fs from 'fs-extra'
-import path from 'path'
-import {
-  ensureFileHasContents
-} from './utils.js'
-import { fileURLToPath } from 'url'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-
 /**
  * @param {string} projectDir
  */
 export async function checkMonorepoFiles (projectDir) {
   console.info('Check monorepo files')
 
-  // disable package-lock.json in monorepos until https://github.com/semantic-release/github/pull/487 is merged
-  await ensureFileHasContents(projectDir, '.npmrc', fs.readFileSync(path.join(__dirname, 'files/npmrc'), {
-    encoding: 'utf-8'
-  }))
+  // we don't need any special files since npm has workspace support,
+  // but if we did, they'd be set up here
 }

--- a/src/check-project/files/npmrc
+++ b/src/check-project/files/npmrc
@@ -1,2 +1,0 @@
-; package-lock with tarball deps breaks lerna/nx - remove when https://github.com/semantic-release/github/pull/487 is merged
-package-lock=false


### PR DESCRIPTION
We had an npmrc to work around a bug in lerna.  Now that lerna can be removed from monorepos we don't need to create the npmrc any more.