### PR TITLE
feat: add release-rc command

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,6 +290,7 @@
     "npm-package-json-lint": "^6.3.0",
     "nyc": "^15.1.0",
     "p-map": "^5.3.0",
+    "p-retry": "^5.1.2",
     "pascalcase": "^2.0.0",
     "path": "^0.12.7",
     "playwright-test": "^8.1.0",

--- a/src/cmds/release-rc.js
+++ b/src/cmds/release-rc.js
@@ -1,0 +1,47 @@
+import releaseRcCmd from '../release-rc.js'
+import { loadUserConfig } from '../config/user.js'
+
+/**
+ * @typedef {import("yargs").Argv} Argv
+ * @typedef {import("yargs").Arguments} Arguments
+ * @typedef {import("yargs").CommandModule} CommandModule
+ */
+
+const EPILOG = `
+Release uses semantic-release (https://github.com/semantic-release/semantic-release#readme.
+`
+
+/** @type {CommandModule} */
+export default {
+  command: 'release-rc',
+  describe: 'Release an RC version of the current module or monorepo',
+  /**
+   * @param {Argv} yargs
+   */
+  builder: async (yargs) => {
+    const userConfig = await loadUserConfig()
+
+    return yargs
+      .epilog(EPILOG)
+      .options({
+        retries: {
+          alias: 'r',
+          type: 'number',
+          describe: 'How many times to retry each publish',
+          default: userConfig.releaseRc.retries
+        },
+        tag: {
+          alias: 't',
+          type: 'string',
+          describe: 'Which tag to publish the version as',
+          default: userConfig.releaseRc.tag
+        }
+      })
+  },
+  /**
+   * @param {any} argv
+   */
+  async handler (argv) {
+    await releaseRcCmd.run(argv)
+  }
+}

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -97,6 +97,10 @@ const defaults = {
     siblingDepUpdateName: 'aegir[bot]',
     siblingDepUpdateEmail: 'aegir[bot]@users.noreply.github.com'
   },
+  releaseRc: {
+    retries: 5,
+    tag: 'next'
+  },
   // dependency check cmd options
   dependencyCheck: {
     input: [

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import dependencyCheckCmd from './cmds/dependency-check.js'
 import lintPackageJsonCmd from './cmds/lint-package-json.js'
 import lintCmd from './cmds/lint.js'
 import releaseCmd from './cmds/release.js'
+import releaseRcCmd from './cmds/release-rc.js'
 import testDependantCmd from './cmds/test-dependant.js'
 import testCmd from './cmds/test.js'
 import docsCmd from './cmds/docs.js'
@@ -89,6 +90,7 @@ async function main () {
   res.command(lintPackageJsonCmd)
   res.command(lintCmd)
   res.command(releaseCmd)
+  res.command(releaseRcCmd)
   res.command(testDependantCmd)
   res.command(testCmd)
   res.command(execCmd)

--- a/src/release-rc.js
+++ b/src/release-rc.js
@@ -1,0 +1,137 @@
+/* eslint-disable no-console */
+
+import Listr from 'listr'
+import { execa } from 'execa'
+import { isMonorepoParent, pkg, everyMonorepoProject } from './utils.js'
+import retry from 'p-retry'
+import fs from 'fs-extra'
+import path from 'path'
+
+/**
+ * @typedef {import("./types").GlobalOptions} GlobalOptions
+ * @typedef {import("./types").ReleaseRcOptions} ReleaseRcOptions
+ * @typedef {import("listr").ListrTaskWrapper} Task
+ */
+
+/**
+ * @param {string} commit
+ * @param {ReleaseRcOptions} ctx
+ */
+async function releaseMonorepoRcs (commit, ctx) {
+  // collect monorepo package versions
+  /** @type {Record<string, string>} */
+  const versions = {}
+
+  await everyMonorepoProject(process.cwd(), async (project) => {
+    if (project.manifest.private === true) {
+      console.info(`Skipping private package ${project.manifest.name}`)
+      return
+    }
+
+    versions[project.manifest.name] = `${project.manifest.version}-${commit}`
+  })
+
+  console.info('Will release the following packages:')
+  console.info('')
+
+  Object.entries(versions).forEach(([name, version]) => {
+    console.info(`  ${name}@${version}`)
+  })
+
+  console.info('')
+
+  // publish packages
+  await everyMonorepoProject(process.cwd(), async (project) => {
+    if (project.manifest.private === true) {
+      console.info(`Skipping private package ${project.manifest.name}`)
+      return
+    }
+
+    console.info(`Updating dependencies of ${project.manifest.name}`)
+
+    versions[project.manifest.name] = `${project.manifest.version}-${commit}`
+
+    project.manifest.version = `${project.manifest.version}-${commit}`
+
+    for (const [name, version] of Object.entries(versions)) {
+      if (project.manifest.dependencies != null && project.manifest.dependencies[name] != null) {
+        console.info(`  Override sibling dependency ${name}@${project.manifest.dependencies[name]} -> ${name}${version}`)
+        project.manifest.dependencies[name] = version
+      }
+
+      if (project.manifest.devDependencies != null && project.manifest.devDependencies[name] != null) {
+        console.info(`  Override sibling dev dependency ${name}@${project.manifest.devDependencies[name]} -> ${name}${version}`)
+        project.manifest.devDependencies[name] = version
+      }
+
+      if (project.manifest.optionalDependencies != null && project.manifest.optionalDependencies[name] != null) {
+        console.info(`  Override sibling optional dependency ${name}@${project.manifest.optionalDependencies[name]} -> ${name}${version}`)
+        project.manifest.optionalDependencies[name] = version
+      }
+    }
+
+    await fs.writeJSON(path.join(project.dir, 'package.json'), project.manifest, {
+      spaces: 2
+    })
+
+    await retry(async () => {
+      console.info(`npm publish --tag ${ctx.tag} --dry-run ${!process.env.CI}`)
+      await execa('npm', ['publish', '--tag', ctx.tag, '--dry-run', `${!process.env.CI}`], {
+        stdout: 'inherit',
+        stderr: 'inherit',
+        cwd: project.dir
+      })
+    }, {
+      retries: ctx.retries
+    })
+
+    console.info('')
+  })
+}
+
+/**
+ * @param {string} commit
+ * @param {ReleaseRcOptions} ctx
+ */
+async function releaseRc (commit, ctx) {
+  if (pkg.private === true) {
+    console.info(`Skipping private package ${pkg.name}`)
+    return
+  }
+
+  console.info(`npm version ${pkg.version}-${commit} --no-git-tag-version`)
+  await execa('npm', ['version', `${pkg.version}-${commit}`, '--no-git-tag-version'], {
+    stdout: 'inherit',
+    stderr: 'inherit'
+  })
+
+  await retry(async () => {
+    console.info(`npm publish --tag ${ctx.tag} --dry-run ${!process.env.CI}`)
+    await execa('npm', ['publish', '--tag', ctx.tag, '--dry-run', `${!process.env.CI}`], {
+      stdout: 'inherit',
+      stderr: 'inherit'
+    })
+  }, {
+    retries: ctx.retries
+  })
+}
+
+const tasks = new Listr([
+  {
+    title: 'Release RC',
+    /**
+     * @param {GlobalOptions & ReleaseRcOptions} ctx
+     */
+    task: async (ctx) => {
+      const commit = await execa('git', ['rev-parse', '--short', 'HEAD'])
+
+      if (isMonorepoParent) {
+        await releaseMonorepoRcs(commit.stdout, ctx)
+      } else {
+        await releaseRc(commit.stdout, ctx)
+      }
+    }
+  }
+], { renderer: 'verbose' })
+
+export default tasks

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,10 @@ interface Options extends GlobalOptions {
    */
   release: ReleaseOptions
   /**
+   * Options for the `release-rc` command
+   */
+  releaseRc: ReleaseRcOptions
+  /**
    * Options for the `dependency-check` command
    */
   dependencyCheck: DependencyCheckOptions
@@ -298,6 +302,18 @@ interface ReleaseOptions {
   siblingDepUpdateEmail: string
 }
 
+interface ReleaseRcOptions {
+  /**
+   * How many times to retry each publish operation
+   */
+  retries: number
+
+  /**
+   * Which tag to publish the rc as
+   */
+  tag: string
+}
+
 interface DependencyCheckOptions {
   /**
    * Files to check
@@ -341,6 +357,7 @@ export type {
   LintOptions,
   TestOptions,
   ReleaseOptions,
+  ReleaseRcOptions,
   DependencyCheckOptions,
   ExecOptions,
   RunOptions


### PR DESCRIPTION
The last thing we use lerna for is releasing RC versions of monorepo packages, so add a command here that does the same thing.

It adds the git hash to the version number, updates sibling dependencies to that new version number then publishes the packages all in the order of dependency.