### PR TITLE
fix: include enums in typedoc index

### DIFF
--- a/src/docs/type-indexer-plugin.cjs
+++ b/src/docs/type-indexer-plugin.cjs
@@ -10,7 +10,8 @@ const MODELS = [
   'Function',
   'Type alias',
   'Variable',
-  'Class'
+  'Class',
+  'Enumeration'
 ]
 
 /**

--- a/test/docs.js
+++ b/test/docs.js
@@ -90,6 +90,12 @@ describe('docs', () => {
     it('should exclude definitions from node_modules', async function () {
       expect(fs.existsSync(join(projectDir, '.docs', 'modules', '_internal_.EventEmitter.html'))).to.be.false('included type from node_modules/@types/node')
     })
+
+    it('should include definitions for enums', async function () {
+      const typedocUrls = await fs.readJSON(join(projectDir, 'dist', 'typedoc-urls.json'))
+
+      expect(typedocUrls).to.have.property('AnEnum')
+    })
   })
 
   describe('monorepo project', () => {

--- a/test/fixtures/projects/a-ts-project/src/index.ts
+++ b/test/fixtures/projects/a-ts-project/src/index.ts
@@ -24,3 +24,8 @@ export interface UsesInternalType extends UsedButNotExported {
 export interface ExtendsEmitter extends EventEmitter {
 
 }
+
+export enum AnEnum {
+  VALUE_1 = 0,
+  VALUE_2
+}


### PR DESCRIPTION
When generating the typedoc index for a module, include enums.