### PR TITLE
fix: do not enforce engines in package.json

### DIFF
--- a/src/check-project/utils.js
+++ b/src/check-project/utils.js
@@ -248,10 +248,6 @@ export function constructManifest (manifest, manifestFields, repoUrl, homePage =
       url: `${repoUrl}/issues`
     },
     keywords: manifest.keywords ? manifest.keywords.sort() : undefined,
-    engines: {
-      node: '>=18.0.0',
-      npm: '>=8.6.0'
-    },
     bin: manifest.bin,
     ...manifestFields,
     scripts: manifest.scripts,

--- a/src/config/.npmpackagejsonlintrc.json
+++ b/src/config/.npmpackagejsonlintrc.json
@@ -11,7 +11,7 @@
       "require-description": "error",
       "require-devDependencies": "off",
       "require-directories": "off",
-      "require-engines": "error",
+      "require-engines": "off",
       "require-files": "error",
       "require-funding": "off",
       "require-homepage": "error" ,


### PR DESCRIPTION
The engines field causes warnings on npm but errors on yarn when the required node version is not met.

Not all of our modules require LTS node and they are used by projects outside of libp2p/helia/etc.

This change removes the automatic addition of an engines field to a project's `package.json` while running the `check-project` command, instead projects that do require a certain node version are free to define it and deal with the breakage that subsequently occurs.

Partial revert of: #1184
Closes: https://github.com/ipfs/aegir/issues/1276