### PR TITLE
fix: add tsconfig to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,9 @@
       "types": "./dist/utils/resolve.d.ts",
       "browser": "./utils/resolve.browser.js",
       "import": "./utils/resolve.js"
+    },
+    "./src/config/tsconfig.aegir.json": {
+      "require": "./src/config/tsconfig.aegir.json"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
TypeScript used to be able to resolve the extends field in `tsconfig.json` using the node require algorithm.

Recent versions of TypeScript have a regression that means that if a module has an exports map, the extendable typescript config file has to be in that exports map so add it here.

Refs: https://github.com/microsoft/TypeScript/issues/53314