### PR TITLE
fix(tsconfig): replace deprecated importsNotUsedAsValues with verbatimModuleSyntax

### DIFF
--- a/src/config/tsconfig.aegir.json
+++ b/src/config/tsconfig.aegir.json
@@ -27,11 +27,11 @@
         "noUnusedLocals": true,
         "noUnusedParameters": false,
         // advanced
-        "importsNotUsedAsValues": "error",
         "forceConsistentCasingInFileNames": true,
         "skipLibCheck": true,
         "stripInternal": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "verbatimModuleSyntax": true
     },
     "include": [
         "src",


### PR DESCRIPTION
The tsconfig raises a warning in VSCode:

```terminal
Option 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
  Use 'verbatimModuleSyntax' instead.
 ```

`importsNotUsedAsValues` will be deprecated in favor of `verbatimModuleSyntax`. (https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) in Typescript 5.5. Might as well get ahead of the curve and remove this warning at the same time.


depends on: https://github.com/ipfs/aegir/pull/1266
