### PR TITLE
fix: stop mixing defaults with config file options

### DIFF
--- a/src/build/index.js
+++ b/src/build/index.js
@@ -54,7 +54,7 @@ const build = async (argv) => {
         'process.env.NODE_ENV': '"production"'
       }
     },
-    argv.fileConfig.build.config
+    argv.fileConfig.build?.config
   ))
 
   if (result.metafile) {

--- a/src/cmds/build.js
+++ b/src/cmds/build.js
@@ -1,5 +1,6 @@
+import merge from 'merge-options'
 import buildCmd from '../build/index.js'
-import { loadUserConfig } from '../config/user.js'
+import { defaultBuildConfig } from '../config/default-build-config.js'
 
 /**
  * @typedef {import("yargs").Argv} Argv
@@ -19,31 +20,30 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
-    const userConfig = await loadUserConfig()
-
     return yargs
       .epilog(EPILOG)
+      .middleware((yargs) => merge(yargs.fileConfig.build, yargs))
       .options({
         bundle: {
           type: 'boolean',
           describe: 'Build the JS standalone bundle.',
-          default: userConfig.build.bundle
+          default: defaultBuildConfig.bundle
         },
         bundlesize: {
           alias: 'b',
           type: 'boolean',
           describe: 'Analyse bundle size.',
-          default: userConfig.build.bundlesize
+          default: defaultBuildConfig.bundlesize
         },
         bundlesizeMax: {
           type: 'string',
           describe: 'Max threshold for the bundle size.',
-          default: userConfig.build.bundlesizeMax
+          default: defaultBuildConfig.bundlesizeMax
         },
         types: {
           type: 'boolean',
           describe: 'If a tsconfig.json is present in the project, run tsc.',
-          default: userConfig.build.types
+          default: defaultBuildConfig.types
         }
       })
   },

--- a/src/cmds/check.js
+++ b/src/cmds/check.js
@@ -8,7 +8,7 @@ import fs from 'fs-extra'
 import kleur from 'kleur'
 import merge from 'merge-options'
 import { readPackageUp } from 'read-pkg-up'
-import { loadUserConfig } from '../config/user.js'
+import { defaultBuildConfig } from '../config/default-build-config.js'
 import { fromRoot, paths } from '../utils.js'
 
 const defaults = merge.bind({
@@ -92,8 +92,7 @@ const checkBuiltins = async (argv) => {
       'process.env.NODE_ENV': '"production"'
     }
   }
-  const userConfig = await loadUserConfig()
-  const result = await esbuild.build(defaults(esbuildOptions, userConfig.build.config))
+  const result = await esbuild.build(defaults(esbuildOptions, defaultBuildConfig))
   if (result.metafile) {
     fs.writeJSONSync(metafile, result.metafile)
   }

--- a/src/cmds/clean.js
+++ b/src/cmds/clean.js
@@ -1,4 +1,5 @@
 import cleanCmd from '../clean.js'
+import { defaultCleanConfig } from '../config/default-clean-config.js'
 
 /**
  * @typedef {import("yargs").Argv} Argv
@@ -22,7 +23,7 @@ export default {
       .epilog(EPILOG)
       .positional('files', {
         array: true,
-        default: ['dist']
+        default: defaultCleanConfig.files
       })
   },
   /**

--- a/src/cmds/dependency-check.js
+++ b/src/cmds/dependency-check.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
-import { loadUserConfig } from '../config/user.js'
+import merge from 'merge-options'
+import { defaultDependencyCheckConfig } from '../config/default-dependency-check-config.js'
 import depCheck from '../dependency-check.js'
 
 /**
@@ -21,22 +22,21 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
-    const userConfig = await loadUserConfig()
-
     return yargs
       .epilog(EPILOG)
+      .middleware((yargs) => merge(yargs.fileConfig.dependencyCheck, yargs))
       .example('aegir dependency-check --unused', 'To check unused packages in your repo.')
       .example('aegir dependency-check --unused --ignore typescript', 'To check unused packages in your repo, ignoring typescript.')
       .option('i', {
         alias: 'ignore',
         describe: 'Ignore these dependencies when considering which are used and which are not',
         array: true,
-        default: userConfig.dependencyCheck.ignore
+        default: defaultDependencyCheckConfig.ignore
       })
       .option('u', {
         alias: 'unused',
         describe: 'Checks for unused dependencies',
-        default: true,
+        default: defaultDependencyCheckConfig.unused,
         type: 'boolean'
       })
   },

--- a/src/cmds/docs.js
+++ b/src/cmds/docs.js
@@ -1,4 +1,5 @@
-import { loadUserConfig } from '../config/user.js'
+import merge from 'merge-options'
+import { defaultDocConfig } from '../config/default-doc-config.js'
 import docsCmd from '../docs.js'
 
 /**
@@ -17,10 +18,9 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
-    const userConfig = await loadUserConfig()
-
     return yargs
       .epilog(EPILOG)
+      .middleware((yargs) => merge(yargs.fileConfig.docs, yargs))
       .example('aegir docs', 'Build HTML documentation.')
       .example('aegir docs -p', 'Build HTML documentation and publish to Github Pages.')
       .options({
@@ -28,33 +28,33 @@ export default {
           alias: 'p',
           type: 'boolean',
           describe: 'Publish to GitHub Pages',
-          default: userConfig.docs.publish
+          default: defaultDocConfig.publish
         },
         entryPoint: {
           type: 'string',
           describe:
             'Specifies the entry points to be documented by TypeDoc. TypeDoc will examine the exports of these files and create documentation according to the exports. Either files or directories may be specified. If a directory is specified, all source files within the directory will be included as an entry point.',
-          default: userConfig.docs.entryPoint
+          default: defaultDocConfig.entryPoint
         },
         message: {
           type: 'string',
           describe: 'The commit message to use when updating the gh-pages branch',
-          default: userConfig.docs.message
+          default: defaultDocConfig.message
         },
         user: {
           type: 'string',
           describe: 'The user name to use when updating the gh-pages branch',
-          default: userConfig.docs.user
+          default: defaultDocConfig.user
         },
         email: {
           type: 'string',
           describe: 'The email address to use when updating the gh-pages branch',
-          default: userConfig.docs.email
+          default: defaultDocConfig.email
         },
         directory: {
           type: 'string',
           describe: 'Where to build the documentation',
-          default: userConfig.docs.directory
+          default: defaultDocConfig.directory
         }
       })
   },

--- a/src/cmds/document-check.js
+++ b/src/cmds/document-check.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
-import { loadUserConfig } from '../config/user.js'
+import merge from 'merge-options'
+import { defaultDocumentCheckConfig } from '../config/default-document-check-config.js'
 import docCheck from '../document-check.js'
 
 /**
@@ -23,20 +24,19 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
-    const userConfig = await loadUserConfig()
-
     return yargs
       .epilog(EPILOG)
+      .middleware((yargs) => merge(yargs.fileConfig.documentCheck, yargs))
       .options({
         inputFiles: {
           array: true,
           describe: 'The files to verify, defaults to `README.md`',
-          default: userConfig.documentCheck.inputFiles
+          default: defaultDocumentCheckConfig.inputFiles
         },
         tsConfigPath: {
           type: 'string',
           describe: 'The path to the `tsconfig.json`, defaults to the root.',
-          default: userConfig.documentCheck.tsConfigPath
+          default: defaultDocumentCheckConfig.tsConfigPath
         }
       })
   },

--- a/src/cmds/exec.js
+++ b/src/cmds/exec.js
@@ -1,4 +1,5 @@
-import { loadUserConfig } from '../config/user.js'
+import merge from 'merge-options'
+import { defaultExecConfig } from '../config/default-exec-config.js'
 import execCmd from '../exec.js'
 
 /**
@@ -20,15 +21,14 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
-    const userConfig = await loadUserConfig()
-
     return yargs
       .epilog(EPILOG)
+      .middleware((yargs) => merge(yargs.fileConfig.exec, yargs))
       .options({
         bail: {
           type: 'boolean',
           describe: '',
-          default: userConfig.build.bundle
+          default: defaultExecConfig.bail
         }
       })
   },

--- a/src/cmds/lint.js
+++ b/src/cmds/lint.js
@@ -1,5 +1,5 @@
-
-import { loadUserConfig } from '../config/user.js'
+import merge from 'merge-options'
+import { defaultLintConfig } from '../config/default-lint-config.js'
 import lintCmd from '../lint.js'
 
 /**
@@ -21,26 +21,25 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
-    const userConfig = await loadUserConfig()
-
     return yargs
       .epilog(EPILOG)
+      .middleware((yargs) => merge(yargs.fileConfig.lint, yargs))
       .options({
         fix: {
           alias: 'f',
           type: 'boolean',
           describe: 'Automatically fix errors if possible.',
-          default: userConfig.lint.fix
+          default: defaultLintConfig.fix
         },
         files: {
           array: true,
           describe: 'Files to lint.',
-          default: userConfig.lint.files
+          default: defaultLintConfig.files
         },
         silent: {
           type: 'boolean',
           describe: 'Disable eslint output.',
-          default: userConfig.lint.silent
+          default: defaultLintConfig.silent
         }
       })
   },

--- a/src/cmds/release-rc.js
+++ b/src/cmds/release-rc.js
@@ -1,4 +1,5 @@
-import { loadUserConfig } from '../config/user.js'
+import merge from 'merge-options'
+import { defaultReleaseRcConfig } from '../config/default-release-rc-config.js'
 import releaseRcCmd from '../release-rc.js'
 
 /**
@@ -19,22 +20,21 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
-    const userConfig = await loadUserConfig()
-
     return yargs
       .epilog(EPILOG)
+      .middleware((yargs) => merge(yargs.fileConfig.releaseRc, yargs))
       .options({
         retries: {
           alias: 'r',
           type: 'number',
           describe: 'How many times to retry each publish',
-          default: userConfig.releaseRc.retries
+          default: defaultReleaseRcConfig.retries
         },
         tag: {
           alias: 't',
           type: 'string',
           describe: 'Which tag to publish the version as',
-          default: userConfig.releaseRc.tag
+          default: defaultReleaseRcConfig.tag
         }
       })
   },

--- a/src/cmds/release.js
+++ b/src/cmds/release.js
@@ -1,4 +1,5 @@
-import { loadUserConfig } from '../config/user.js'
+import merge from 'merge-options'
+import { defaultReleaseConfig } from '../config/default-release-config.js'
 import releaseCmd from '../release.js'
 
 /**
@@ -19,26 +20,25 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
-    const userConfig = await loadUserConfig()
-
     return yargs
       .epilog(EPILOG)
+      .middleware((yargs) => merge(yargs.fileConfig.release, yargs))
       .options({
         siblingDepUpdateMessage: {
           alias: 'm',
           type: 'string',
           describe: 'The commit message to use when updating sibling dependencies',
-          default: userConfig.release.siblingDepUpdateMessage
+          default: defaultReleaseConfig.siblingDepUpdateMessage
         },
         siblingDepUpdateName: {
           type: 'string',
           describe: 'The user name to use when updating sibling dependencies',
-          default: userConfig.release.siblingDepUpdateName
+          default: defaultReleaseConfig.siblingDepUpdateName
         },
         siblingDepUpdateEmail: {
           type: 'string',
           describe: 'The email to use when updating sibling dependencies',
-          default: userConfig.release.siblingDepUpdateEmail
+          default: defaultReleaseConfig.siblingDepUpdateEmail
         }
       })
   },

--- a/src/cmds/run.js
+++ b/src/cmds/run.js
@@ -1,4 +1,5 @@
-import { loadUserConfig } from '../config/user.js'
+import merge from 'merge-options'
+import { defaultRunConfig } from '../config/default-run-config.js'
 import runCmd from '../run.js'
 
 /**
@@ -20,15 +21,14 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
-    const userConfig = await loadUserConfig()
-
     return yargs
       .epilog(EPILOG)
+      .middleware((yargs) => merge(yargs.fileConfig.run, yargs))
       .options({
         bail: {
           type: 'boolean',
           describe: '',
-          default: userConfig.build.bundle
+          default: defaultRunConfig.bail
         }
       })
       .positional('script', {

--- a/src/cmds/test-dependant.js
+++ b/src/cmds/test-dependant.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import merge from 'merge-options'
 import testDependantCmd from '../test-dependant/index.js'
 
 /**
@@ -15,6 +16,7 @@ export default {
    */
   builder: (yargs) => {
     return yargs
+      .middleware((yargs) => merge(yargs.fileConfig.testDependant, yargs))
       .options({
         repo: {
           describe: 'The dependant module\'s repo URL',

--- a/src/cmds/test.js
+++ b/src/cmds/test.js
@@ -1,5 +1,7 @@
 import kleur from 'kleur'
-import { loadUserConfig } from '../config/user.js'
+import merge from 'merge-options'
+import { defaultBuildConfig } from '../config/default-build-config.js'
+import { defaultTestConfig } from '../config/default-test-config.js'
 import testCmd from '../test/index.js'
 
 /**
@@ -20,10 +22,9 @@ export default {
    * @param {Argv} yargs
    */
   builder: async (yargs) => {
-    const userConfig = await loadUserConfig()
-
     return yargs
       .epilog(EPILOG)
+      .middleware((yargs) => merge(yargs.fileConfig.test, yargs))
       .example(
         'aegir test -t webworker',
         'Run tests in the browser inside a webworker.'
@@ -49,57 +50,63 @@ export default {
           alias: 'b',
           describe: 'Build the project before running the tests',
           type: 'boolean',
-          default: userConfig.test.build
+          default: defaultTestConfig.build
         },
         types: {
           type: 'boolean',
           describe: 'If a tsconfig.json is present in the project, run tsc.',
-          default: userConfig.build.types
+          default: defaultBuildConfig.types
         },
         target: {
           alias: 't',
           describe: 'In which target environment to execute the tests',
           array: true,
           choices: ['node', 'browser', 'webworker', 'electron-main', 'electron-renderer', 'react-native-android', 'react-native-ios'],
-          default: userConfig.test.target
+          default: defaultTestConfig.target
         },
         watch: {
           alias: 'w',
           describe: 'Watch files for changes and rerun tests',
           type: 'boolean',
-          default: userConfig.test.watch
+          default: defaultTestConfig.watch
         },
         files: {
           alias: 'f',
           describe: 'Custom globs for files to test',
           array: true,
-          default: userConfig.test.files
+          default: defaultTestConfig.files
         },
         timeout: {
           describe: 'The default time a single test has to run',
           type: 'number',
-          default: userConfig.test.timeout
+          default: defaultTestConfig.timeout
         },
         grep: {
           alias: 'g',
           type: 'string',
-          describe: 'Limit tests to those whose names match given pattern'
+          describe: 'Limit tests to those whose names match given pattern',
+          default: defaultTestConfig.grep
         },
         bail: {
           alias: 'b',
           describe: 'Mocha should bail once a test fails',
           type: 'boolean',
-          default: userConfig.test.bail
+          default: defaultTestConfig.bail
         },
         progress: {
           describe: 'Use progress reporters on mocha and karma',
           type: 'boolean',
-          default: userConfig.test.progress
+          default: defaultTestConfig.progress
         },
         cov: {
           describe: 'Enable coverage output. Output is already in Istanbul JSON format and can be uploaded directly to codecov.',
           type: 'boolean',
-          default: userConfig.test.cov
+          default: defaultTestConfig.cov
+        },
+        runner: {
+          describe: 'The platform running the code. Important for differentiating between browser, electron, react-native, etc.',
+          type: 'string',
+          default: defaultTestConfig.runner
         }
       })
   },

--- a/src/config/default-aegir-config.js
+++ b/src/config/default-aegir-config.js
@@ -1,0 +1,3 @@
+export const defaultAegirConfig = {
+  debug: false
+}

--- a/src/config/default-build-config.js
+++ b/src/config/default-build-config.js
@@ -1,0 +1,7 @@
+export const defaultBuildConfig = {
+  bundle: true,
+  bundlesize: false,
+  bundlesizeMax: '100kB',
+  types: true,
+  config: {}
+}

--- a/src/config/default-clean-config.js
+++ b/src/config/default-clean-config.js
@@ -1,0 +1,3 @@
+export const defaultCleanConfig = {
+  files: ['dist']
+}

--- a/src/config/default-dependency-check-config.js
+++ b/src/config/default-dependency-check-config.js
@@ -1,0 +1,4 @@
+export const defaultDependencyCheckConfig = {
+  unused: true,
+  ignore: []
+}

--- a/src/config/default-doc-config.js
+++ b/src/config/default-doc-config.js
@@ -1,0 +1,8 @@
+export const defaultDocConfig = {
+  publish: Boolean(process.env.CI),
+  entryPoint: 'src/index.{js,ts}',
+  message: 'docs: update documentation [skip ci]',
+  user: 'aegir[bot]',
+  email: 'aegir[bot]@users.noreply.github.com',
+  directory: '.docs'
+}

--- a/src/config/default-document-check-config.js
+++ b/src/config/default-document-check-config.js
@@ -1,0 +1,7 @@
+export const defaultDocumentCheckConfig = {
+  inputFiles: [
+    '*.md',
+    'src/*.md'
+  ],
+  tsConfigPath: '.'
+}

--- a/src/config/default-exec-config.js
+++ b/src/config/default-exec-config.js
@@ -1,0 +1,3 @@
+export const defaultExecConfig = {
+  bail: true
+}

--- a/src/config/default-lint-config.js
+++ b/src/config/default-lint-config.js
@@ -1,0 +1,15 @@
+export const defaultLintConfig = {
+  silent: false,
+  fix: false,
+  files: [
+    '*.{js,ts}',
+    'bin/**',
+    'config/**/*.{js,ts}',
+    'test/**/*.{js,ts}',
+    'src/**/*.{js,ts}',
+    'tasks/**/*.{js,ts}',
+    'benchmarks/**/*.{js,ts}',
+    'utils/**/*.{js,ts}',
+    '!**/node_modules/**'
+  ]
+}

--- a/src/config/default-release-config.js
+++ b/src/config/default-release-config.js
@@ -1,0 +1,23 @@
+export const defaultReleaseConfig = {
+  build: true,
+  types: true,
+  test: true,
+  lint: true,
+  contributors: true,
+  bump: true,
+  changelog: true,
+  publish: true,
+  commit: true,
+  tag: true,
+  push: true,
+  ghrelease: true,
+  docs: true,
+  ghtoken: '',
+  type: 'patch',
+  preid: undefined,
+  distTag: 'latest',
+  remote: 'origin',
+  siblingDepUpdateMessage: 'deps: update sibling dependencies',
+  siblingDepUpdateName: 'aegir[bot]',
+  siblingDepUpdateEmail: 'aegir[bot]@users.noreply.github.com'
+}

--- a/src/config/default-release-rc-config.js
+++ b/src/config/default-release-rc-config.js
@@ -1,0 +1,4 @@
+export const defaultReleaseRcConfig = {
+  retries: 5,
+  tag: 'next'
+}

--- a/src/config/default-run-config.js
+++ b/src/config/default-run-config.js
@@ -1,0 +1,3 @@
+export const defaultRunConfig = {
+  bail: true
+}

--- a/src/config/default-test-config.js
+++ b/src/config/default-test-config.js
@@ -1,0 +1,12 @@
+export const defaultTestConfig = {
+  build: true,
+  runner: 'node',
+  target: ['node', 'browser', 'webworker'],
+  watch: false,
+  files: [],
+  timeout: 60000,
+  grep: '',
+  bail: false,
+  progress: false,
+  cov: false
+}

--- a/src/config/pw-test.js
+++ b/src/config/pw-test.js
@@ -1,7 +1,15 @@
 import { loadUserConfig } from './user.js'
 
+const defaultBrowserConfig = {
+  config: {
+    buildConfig: {
+      conditions: ['production']
+    }
+  }
+}
+
 export default async () => {
   const userConfig = await loadUserConfig()
 
-  return userConfig.test.browser.config || {}
+  return userConfig.test?.browser?.config || defaultBrowserConfig
 }

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -2,125 +2,10 @@
 
 import { pathToFileURL } from 'url'
 import { lilconfig } from 'lilconfig'
-import merge from 'merge-options'
-import { isTypescript } from '../utils.js'
 
 /**
  * @typedef {import("./../types").Options} Options
  */
-
-/** @type {Omit<Options, "fileConfig">} */
-const defaults = {
-  // global options
-  debug: false,
-  // test cmd options
-  test: {
-    build: true,
-    runner: 'node',
-    target: ['node', 'browser', 'webworker'],
-    watch: false,
-    files: [],
-    timeout: 60000,
-    grep: '',
-    bail: false,
-    progress: false,
-    cov: false,
-    browser: {
-      config: {
-        buildConfig: {
-          conditions: ['production']
-        }
-      }
-    },
-    before: async () => { return undefined },
-    after: async () => {}
-  },
-  // build cmd options
-  build: {
-    bundle: true,
-    bundlesize: false,
-    bundlesizeMax: '100kB',
-    types: true,
-    config: {}
-  },
-  // linter cmd options
-  lint: {
-    silent: false,
-    fix: false,
-    files: [
-      '*.{js,ts}',
-      'bin/**',
-      'config/**/*.{js,ts}',
-      'test/**/*.{js,ts}',
-      'src/**/*.{js,ts}',
-      'tasks/**/*.{js,ts}',
-      'benchmarks/**/*.{js,ts}',
-      'utils/**/*.{js,ts}',
-      '!**/node_modules/**'
-    ]
-  },
-  // docs cmd options
-  docs: {
-    publish: Boolean(process.env.CI),
-    entryPoint: isTypescript ? 'src/index.ts' : 'src/index.js',
-    message: 'docs: update documentation [skip ci]',
-    user: 'aegir[bot]',
-    email: 'aegir[bot]@users.noreply.github.com',
-    directory: '.docs'
-  },
-  // document check cmd options
-  documentCheck: {
-    inputFiles: [
-      '*.md',
-      'src/*.md'
-    ],
-    tsConfigPath: '.'
-  },
-  // ts cmd options
-  ts: {
-    preset: undefined,
-    include: []
-  },
-  // release cmd options
-  release: {
-    build: true,
-    types: true,
-    test: true,
-    lint: true,
-    contributors: true,
-    bump: true,
-    changelog: true,
-    publish: true,
-    commit: true,
-    tag: true,
-    push: true,
-    ghrelease: true,
-    docs: true,
-    ghtoken: '',
-    type: 'patch',
-    preid: undefined,
-    distTag: 'latest',
-    remote: 'origin',
-    siblingDepUpdateMessage: 'deps: update sibling dependencies',
-    siblingDepUpdateName: 'aegir[bot]',
-    siblingDepUpdateEmail: 'aegir[bot]@users.noreply.github.com'
-  },
-  releaseRc: {
-    retries: 5,
-    tag: 'next'
-  },
-  // dependency check cmd options
-  dependencyCheck: {
-    unused: false,
-    ignore: []
-  },
-  exec: {
-    bail: true
-  },
-  run: {
-    bail: true
-  }
-}
 
 /**
  * Search for local user config
@@ -169,12 +54,7 @@ export const config = async (searchFrom) => {
     throw new Error('Error finding your config file.')
   }
 
-  const conf = /** @type {Options} */(merge(
-    defaults,
-    userConfig
-  ))
-
-  return conf
+  return userConfig
 }
 
 export const loadUserConfig = () => config()

--- a/src/dependency-check.js
+++ b/src/dependency-check.js
@@ -38,7 +38,7 @@ const tasks = new Listr(
             '**/*.cjs': depcheck.parser.es6,
             '**/*.mjs': depcheck.parser.es6
           },
-          ignoreMatches: ignoredDevDependencies.concat(ctx.fileConfig.dependencyCheck.ignore).concat(ctx.ignore)
+          ignoreMatches: ignoredDevDependencies.concat(ctx.fileConfig?.dependencyCheck?.ignore || []).concat(ctx.ignore)
         })
 
         if (Object.keys(result.missing).length > 0 || result.dependencies.length > 0 || result.devDependencies.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ import releaseCmd from './cmds/release.js'
 import runCmd from './cmds/run.js'
 import testDependantCmd from './cmds/test-dependant.js'
 import testCmd from './cmds/test.js'
+import { defaultAegirConfig } from './config/default-aegir-config.js'
 import { loadUserConfig } from './config/user.js'
 
 /**
@@ -71,7 +72,7 @@ async function main () {
       desc: 'Show debug output.',
       type: 'boolean',
       alias: 'd',
-      default: userConfig.debug
+      default: defaultAegirConfig.debug
     })
     .group(['help', 'version', 'debug'], 'Global Options:')
     .demandCommand(1, 'You need at least one command.')

--- a/src/test/browser.js
+++ b/src/test/browser.js
@@ -37,7 +37,7 @@ export default async (argv, execaOptions) => {
       ]
 
   // before hook
-  const before = await argv.fileConfig.test.before(argv)
+  const before = await argv.fileConfig.test?.before?.(argv)
   const beforeEnv = before && before.env ? before.env : {}
 
   // run pw-test
@@ -66,5 +66,5 @@ export default async (argv, execaOptions) => {
   )
 
   // after hook
-  await argv.fileConfig.test.after(argv, before)
+  await argv.fileConfig.test?.after?.(argv, before)
 }

--- a/src/test/electron.js
+++ b/src/test/electron.js
@@ -33,7 +33,7 @@ export default async (argv, execaOptions) => {
   const renderer = argv.runner === 'electron-renderer' ? ['--renderer'] : []
 
   // before hook
-  const before = await argv.fileConfig.test.before(argv)
+  const before = await argv.fileConfig.test?.before?.(argv)
   const beforeEnv = before && before.env ? before.env : {}
   const electronPath = await getElectron()
 
@@ -64,5 +64,5 @@ export default async (argv, execaOptions) => {
     execaOptions)
   )
   // after hook
-  await argv.fileConfig.test.after(argv, before)
+  await argv.fileConfig.test?.after?.(argv, before)
 }

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -64,7 +64,7 @@ export default async function testNode (argv, execaOptions) {
   }
 
   // before hook
-  const before = await argv.fileConfig.test.before(argv)
+  const before = await argv.fileConfig.test?.before?.(argv)
   const beforeEnv = before && before.env ? before.env : {}
 
   // run mocha
@@ -84,5 +84,5 @@ export default async function testNode (argv, execaOptions) {
     )
   )
   // after hook
-  await argv.fileConfig.test.after(argv, before)
+  await argv.fileConfig.test?.after?.(argv, before)
 }

--- a/src/test/react-native.js
+++ b/src/test/react-native.js
@@ -34,7 +34,7 @@ export default async (argv, execaOptions) => {
       ]
 
   // before hook
-  const before = await argv.fileConfig.test.before(argv)
+  const before = await argv.fileConfig.test?.before?.(argv)
   const beforeEnv = before && before.env ? before.env : {}
 
   await checkAndroidEnv()
@@ -74,7 +74,7 @@ export default async (argv, execaOptions) => {
   )
 
   // after hook
-  await argv.fileConfig.test.after(argv, before)
+  await argv.fileConfig.test?.after?.(argv, before)
 }
 
 /**

--- a/test/config/fixtures/custom-config/.aegir.js
+++ b/test/config/fixtures/custom-config/.aegir.js
@@ -1,3 +1,7 @@
 module.exports = {
-   
+   debug: false,
+   test: {
+    before: () => undefined,
+    after: () => undefined
+   }
 };

--- a/test/lint.js
+++ b/test/lint.js
@@ -4,6 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { premove as del } from 'premove/sync'
+import { defaultLintConfig } from '../src/config/default-lint-config.js'
 import { loadUserConfig } from '../src/config/user.js'
 import lint from '../src/lint.js'
 import { expect } from '../utils/chai.js'
@@ -42,7 +43,7 @@ const projectShouldPassLint = async (project) => {
   await lint.run({
     fileConfig: userConfig,
     debug: false,
-    ...userConfig.lint
+    ...defaultLintConfig
   })
 }
 
@@ -57,7 +58,7 @@ const projectShouldFailLint = async (project) => {
     await lint.run({
       fileConfig: userConfig,
       debug: false,
-      ...userConfig.lint
+      ...defaultLintConfig
     })
   } catch (/** @type {any} */ error) {
     failed = true
@@ -86,7 +87,7 @@ describe('lint', () => {
       debug: false,
       fix: false,
       silent: true,
-      files: userConfig.lint.files
+      files: defaultLintConfig.files
     })
   })
 
@@ -134,7 +135,7 @@ describe('lint', () => {
     await lint.run({
       fileConfig: userConfig,
       debug: false,
-      ...userConfig.lint
+      ...defaultLintConfig
     })
   })
 


### PR DESCRIPTION
## Context

This is one of the PRs aimed at addressing point 3 of the blockers I ran into in #136.

As a side affect of solving the issue, I might of solved a few others. Before this change, the merged defaults & config file were treated as the defaults as well as the fileConfig. However, that can lead to some odd bugs.

For example, one of the test cases for `loadUserConfig` incorrectly passed for a config file that contained nothing due to the defaults acting the a config file.