### PR TITLE
chore: fix linting

### DIFF
--- a/src/check-project/check-licence-files.js
+++ b/src/check-project/check-licence-files.js
@@ -1,4 +1,3 @@
-
 /* eslint-disable no-console */
 
 import path from 'path'

--- a/src/check-project/check-monorepo-readme.js
+++ b/src/check-project/check-monorepo-readme.js
@@ -1,4 +1,3 @@
-
 /* eslint-disable no-console */
 
 import path from 'path'

--- a/src/check-project/check-readme.js
+++ b/src/check-project/check-readme.js
@@ -1,4 +1,3 @@
-
 /* eslint-disable no-console,complexity */
 
 import path from 'path'

--- a/src/cmds/lint-package-json.js
+++ b/src/cmds/lint-package-json.js
@@ -1,4 +1,3 @@
-
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { execa } from 'execa'

--- a/src/cmds/lint.js
+++ b/src/cmds/lint.js
@@ -1,4 +1,3 @@
-
 import { loadUserConfig } from '../config/user.js'
 import lintCmd from '../lint.js'
 

--- a/test/fixtures/dependency-check/pass/index.js
+++ b/test/fixtures/dependency-check/pass/index.js
@@ -1,4 +1,3 @@
-
 /* eslint-disable no-unused-vars */
 
 // @ts-ignore

--- a/test/fixtures/js+ts/src/some.js
+++ b/test/fixtures/js+ts/src/some.js
@@ -1,4 +1,3 @@
-
 export const main = () => {
 
 }

--- a/test/fixtures/tests/context-access.js
+++ b/test/fixtures/tests/context-access.js
@@ -1,3 +1,2 @@
-
 // export something from the global scope
 export default Uint8Array

--- a/test/utils/get-port.js
+++ b/test/utils/get-port.js
@@ -1,4 +1,3 @@
-
 /* eslint-env mocha */
 
 import { expect } from '../../utils/chai.js'


### PR DESCRIPTION
[This commit](https://github.com/standard/eslint-config-standard/commit/9673e0bb5a04d0d4b04333e33731514210a16664) to `eslint-config-standard` altered the `no-multiple-empty-lines` rule so update to the new linting rules.