### PR TITLE
fix: handle invalid workspace entries

### DIFF
--- a/src/check-project/index.js
+++ b/src/check-project/index.js
@@ -113,7 +113,19 @@ async function processMonorepo (projectDir, manifest, branchName, repoUrl) {
       cwd: projectDir,
       absolute: true
     })) {
-      const pkg = fs.readJSONSync(path.join(subProjectDir, 'package.json'))
+      const stat = await fs.stat(subProjectDir)
+
+      if (!stat.isDirectory()) {
+        continue
+      }
+
+      const manfest = path.join(subProjectDir, 'package.json')
+
+      if (!fs.existsSync(manfest)) {
+        continue
+      }
+
+      const pkg = fs.readJSONSync(manfest)
       const homePage = `${repoUrl}/tree/master${subProjectDir.substring(projectDir.length)}`
 
       console.info('Found monorepo project', pkg.name)

--- a/src/utils.js
+++ b/src/utils.js
@@ -371,7 +371,19 @@ async function parseProjects (projectDir, workspaces) {
       cwd: projectDir,
       absolute: true
     })) {
-      const pkg = fs.readJSONSync(path.join(subProjectDir, 'package.json'))
+      const stat = await fs.stat(subProjectDir)
+
+      if (!stat.isDirectory()) {
+        continue
+      }
+
+      const manfest = path.join(subProjectDir, 'package.json')
+
+      if (!fs.existsSync(manfest)) {
+        continue
+      }
+
+      const pkg = fs.readJSONSync(manfest)
 
       projects[pkg.name] = {
         manifest: pkg,


### PR DESCRIPTION
Test that workspace entries are directories and have package.json files before processing them.