### PR TITLE
fix: allow specifying ci file in check-project

### DIFF
--- a/src/check-project/check-monorepo-readme.js
+++ b/src/check-project/check-monorepo-readme.js
@@ -17,8 +17,9 @@ import {
  * @param {string} repoUrl
  * @param {string} defaultBranch
  * @param {string[]} projectDirs
+ * @param {string} ciFile
  */
-export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, projectDirs) {
+export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, projectDirs, ciFile) {
   const repoParts = repoUrl.split('/')
   const repoName = repoParts.pop()
   const repoOwner = repoParts.pop()
@@ -47,7 +48,7 @@ export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, p
   const file = parseMarkdown(readmeContents)
 
   // create basic readme with heading, CI link, etc
-  const readme = parseMarkdown(HEADER(pkg, repoOwner, repoName, defaultBranch))
+  const readme = parseMarkdown(HEADER(pkg, repoOwner, repoName, defaultBranch, ciFile))
 
   // remove existing header, CI link, etc
   /** @type {import('mdast').Root} */

--- a/src/check-project/check-readme.js
+++ b/src/check-project/check-readme.js
@@ -16,9 +16,10 @@ import {
  * @param {string} projectDir
  * @param {string} repoUrl
  * @param {string} defaultBranch
+ * @param {string} ciFile
  * @param {any} [rootManifest]
  */
-export async function checkReadme (projectDir, repoUrl, defaultBranch, rootManifest) {
+export async function checkReadme (projectDir, repoUrl, defaultBranch, ciFile, rootManifest) {
   const repoParts = repoUrl.split('/')
   const repoName = repoParts.pop()
   const repoOwner = repoParts.pop()
@@ -47,7 +48,7 @@ export async function checkReadme (projectDir, repoUrl, defaultBranch, rootManif
   const file = parseMarkdown(readmeContents)
 
   // create basic readme with heading, CI link, etc
-  const readme = parseMarkdown(HEADER(pkg, repoOwner, repoName, defaultBranch))
+  const readme = parseMarkdown(HEADER(pkg, repoOwner, repoName, defaultBranch, ciFile))
 
   // remove existing header, CI link, etc
   /** @type {import('mdast').Root} */

--- a/src/check-project/manifests/untyped-esm.js
+++ b/src/check-project/manifests/untyped-esm.js
@@ -1,0 +1,56 @@
+import mergeOptions from 'merge-options'
+import { semanticReleaseConfig } from '../semantic-release-config.js'
+import {
+  sortFields,
+  constructManifest
+} from '../utils.js'
+
+const merge = mergeOptions.bind({ ignoreUndefined: true })
+
+/**
+ * @param {any} manifest
+ * @param {string} branchName
+ * @param {string} repoUrl
+ * @param {string} [homePage]
+ */
+export async function untypedESMManifest (manifest, branchName, repoUrl, homePage = repoUrl) {
+  let proposedManifest = constructManifest(manifest, {
+    type: 'module',
+    files: [
+      'src',
+      'dist',
+      '!dist/test',
+      '!**/*.tsbuildinfo'
+    ],
+    exports: {
+      '.': {
+        types: './dist/src/index.d.ts',
+        import: './src/index.js'
+      }
+    },
+    eslintConfig: merge({
+      extends: 'ipfs',
+      parserOptions: {
+        sourceType: 'module'
+      }
+    }, manifest.eslintConfig),
+    release: (manifest.scripts?.release?.includes('semantic-release') || manifest.scripts?.release?.includes('aegir release')) ? semanticReleaseConfig(branchName) : undefined
+  }, repoUrl, homePage)
+
+  const rest = {
+    ...sortFields(manifest)
+  }
+
+  for (const key of Object.keys(proposedManifest)) {
+    delete rest[key]
+  }
+
+  proposedManifest = {
+    ...proposedManifest,
+    ...rest,
+    contributors: undefined,
+    leadMaintainer: undefined
+  }
+
+  return proposedManifest
+}

--- a/src/check-project/readme/header.js
+++ b/src/check-project/readme/header.js
@@ -1,27 +1,27 @@
 /**
- * @type {Record<string, (repoOwner: string, repoName: string, defaultBranch: string) => string>}
+ * @type {Record<string, (repoOwner: string, repoName: string, defaultBranch: string, ciFile: string) => string>}
  */
 const BADGES = {
-  libp2p: (repoOwner, repoName, defaultBranch) => `
+  libp2p: (repoOwner, repoName, defaultBranch, ciFile) => `
 [![libp2p.io](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![Discuss](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg?style=flat-square)](https://discuss.libp2p.io)
 [![codecov](https://img.shields.io/codecov/c/github/${repoOwner}/${repoName}.svg?style=flat-square)](https://codecov.io/gh/${repoOwner}/${repoName})
-[![CI](https://img.shields.io/github/actions/workflow/status/${repoOwner}/${repoName}/js-test-and-release.yml?branch=${defaultBranch}&style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/js-test-and-release.yml?query=branch%3A${defaultBranch})
+[![CI](https://img.shields.io/github/actions/workflow/status/${repoOwner}/${repoName}/${ciFile}?branch=${defaultBranch}&style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/${ciFile}?query=branch%3A${defaultBranch})
   `,
-  ipfs: (repoOwner, repoName, defaultBranch) => `
+  ipfs: (repoOwner, repoName, defaultBranch, ciFile) => `
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)
 [![Discuss](https://img.shields.io/discourse/https/discuss.ipfs.tech/posts.svg?style=flat-square)](https://discuss.ipfs.tech)
 [![codecov](https://img.shields.io/codecov/c/github/${repoOwner}/${repoName}.svg?style=flat-square)](https://codecov.io/gh/${repoOwner}/${repoName})
-[![CI](https://img.shields.io/github/actions/workflow/status/${repoOwner}/${repoName}/js-test-and-release.yml?branch=${defaultBranch}&style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/js-test-and-release.yml?query=branch%3A${defaultBranch})
+[![CI](https://img.shields.io/github/actions/workflow/status/${repoOwner}/${repoName}/${ciFile}?branch=${defaultBranch}&style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/${ciFile}?query=branch%3A${defaultBranch})
   `,
-  multiformats: (repoOwner, repoName, defaultBranch) => `
+  multiformats: (repoOwner, repoName, defaultBranch, ciFile) => `
 [![multiformats.io](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://multiformats.io)
 [![codecov](https://img.shields.io/codecov/c/github/${repoOwner}/${repoName}.svg?style=flat-square)](https://codecov.io/gh/${repoOwner}/${repoName})
-[![CI](https://img.shields.io/github/actions/workflow/status/${repoOwner}/${repoName}/js-test-and-release.yml?branch=${defaultBranch}&style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/js-test-and-release.yml?query=branch%3A${defaultBranch})
+[![CI](https://img.shields.io/github/actions/workflow/status/${repoOwner}/${repoName}/${ciFile}?branch=${defaultBranch}&style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/${ciFile}?query=branch%3A${defaultBranch})
   `,
-  default: (repoOwner, repoName, defaultBranch) => `
+  default: (repoOwner, repoName, defaultBranch, ciFile) => `
 [![codecov](https://img.shields.io/codecov/c/github/${repoOwner}/${repoName}.svg?style=flat-square)](https://codecov.io/gh/${repoOwner}/${repoName})
-[![CI](https://img.shields.io/github/actions/workflow/status/${repoOwner}/${repoName}/js-test-and-release.yml?branch=${defaultBranch}&style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/js-test-and-release.yml?query=branch%3A${defaultBranch})
+[![CI](https://img.shields.io/github/actions/workflow/status/${repoOwner}/${repoName}/${ciFile}?branch=${defaultBranch}&style=flat-square)](https://github.com/${repoOwner}/${repoName}/actions/workflows/${ciFile}?query=branch%3A${defaultBranch})
   `
 }
 
@@ -30,12 +30,13 @@ const BADGES = {
  * @param {string} repoOwner
  * @param {string} repoName
  * @param {string} defaultBranch
+ * @param {string} ciFile
  */
-export const HEADER = (pkg, repoOwner, repoName, defaultBranch) => {
+export const HEADER = (pkg, repoOwner, repoName, defaultBranch, ciFile) => {
   return `
 # ${pkg.name} <!-- omit in toc -->
 
-${(BADGES[repoOwner] ?? BADGES.default)(repoOwner, repoName, defaultBranch).trim()}
+${(BADGES[repoOwner] ?? BADGES.default)(repoOwner, repoName, defaultBranch, ciFile).trim()}
 
 > ${pkg.description}
 


### PR DESCRIPTION
Not all projects use js-test-and-release.yml as their main CI file so allow specifying something different.