### PR TITLE
fix: when generating api doc link, check typedoc entry point

### DIFF
--- a/src/check-project/readme/api-docs.js
+++ b/src/check-project/readme/api-docs.js
@@ -3,6 +3,12 @@
  * @param {*} [parentManifest]
  */
 export const APIDOCS = (pkg, parentManifest) => {
+  // monorepo project - test for typedoc entry point
+  if (parentManifest != null && pkg.typedoc?.entryPoint == null) {
+    return ''
+  }
+
+  // test for docs script in monorepo root or package
   const scripts = parentManifest?.scripts ?? pkg.scripts ?? {}
 
   if (scripts.docs == null) {


### PR DESCRIPTION
If a package is in a monorepo and it has no typedoc entry point no API doc link should be generated.