### PR TITLE
fix: hard code mocha runner for pw-test

### DIFF
--- a/src/test/browser.js
+++ b/src/test/browser.js
@@ -45,6 +45,10 @@ export default async (argv, execaOptions) => {
     [
       ...files,
       '--mode', argv.runner === 'browser' ? 'main' : 'worker',
+      // autodetect is broken in pw-test
+      // https://github.com/hugomrdias/playwright-test/issues/573
+      // https://github.com/hugomrdias/playwright-test/issues/572
+      '--runner', 'mocha',
       ...watch,
       ...cov,
       '--config', fromAegir('src/config/pw-test.js'),


### PR DESCRIPTION
Autodetecting test runners is broken in playwright test. We only use mocha so just pass it in as an option.

Refs:

- https://github.com/hugomrdias/playwright-test/issues/573
- https://github.com/hugomrdias/playwright-test/issues/572