### PR TITLE
fix: make updating sibling deps a chore

### DIFF
--- a/src/config/user.js
+++ b/src/config/user.js
@@ -101,7 +101,7 @@ const defaults = {
     preid: undefined,
     distTag: 'latest',
     remote: 'origin',
-    siblingDepUpdateMessage: 'deps: update sibling dependencies',
+    siblingDepUpdateMessage: 'chore: update sibling dependencies',
     siblingDepUpdateName: 'aegir[bot]',
     siblingDepUpdateEmail: 'aegir[bot]@users.noreply.github.com'
   },


### PR DESCRIPTION
This is done after a release so make it a chore to prevent it causing release-please to create a new release.