### PR TITLE
fix: check monorepo root for docs

### DIFF
--- a/src/check-project/readme/api-docs.js
+++ b/src/check-project/readme/api-docs.js
@@ -3,11 +3,6 @@
  * @param {*} [parentManifest]
  */
 export const APIDOCS = (pkg, parentManifest) => {
-  // monorepo project - test for typedoc entry point
-  if (parentManifest != null && pkg.typedoc?.entryPoint == null) {
-    return ''
-  }
-
   // test for docs script in monorepo root or package
   const scripts = parentManifest?.scripts ?? pkg.scripts ?? {}
 


### PR DESCRIPTION
When building docs for monorepos, the typedoc manifest key is no longer used so just check for docs in the root.