### PR TITLE
deps!: update eslint-config-ipfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,7 +258,7 @@
     "env-paths": "^3.0.0",
     "esbuild": "^0.19.2",
     "eslint": "^8.31.0",
-    "eslint-config-ipfs": "^5.0.0",
+    "eslint-config-ipfs": "^6.0.0",
     "eslint-plugin-etc": "^2.0.2",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-jsdoc": "^46.4.3",

--- a/src/types.ts
+++ b/src/types.ts
@@ -253,12 +253,12 @@ interface TestOptions {
    * Before tests hook
    */
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-  before: (options: GlobalOptions & TestOptions) => Promise<TestBeforeResult | void >
+  before(options: GlobalOptions & TestOptions): Promise<TestBeforeResult | void >
   /**
    * After tests hook
    */
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-  after: (options: GlobalOptions & TestOptions, beforeResult: TestBeforeResult | void) => Promise<void>
+  after(options: GlobalOptions & TestOptions, beforeResult: TestBeforeResult | void): Promise<void>
 }
 
 interface TestBeforeResult {

--- a/test/fixtures/projects/a-monorepo/packages/a-workspace-project/src/types.ts
+++ b/test/fixtures/projects/a-monorepo/packages/a-workspace-project/src/types.ts
@@ -1,3 +1,3 @@
 export interface ExportedButNotInExports {
-  aMethod: () => void
+  aMethod(): void
 }

--- a/test/fixtures/projects/a-monorepo/packages/another-workspace-project/src/types.ts
+++ b/test/fixtures/projects/a-monorepo/packages/another-workspace-project/src/types.ts
@@ -1,3 +1,3 @@
 export interface ExportedButNotInExports {
-  aMethod: () => void
+  aMethod(): void
 }

--- a/test/fixtures/projects/a-ts-project/src/a-module.ts
+++ b/test/fixtures/projects/a-ts-project/src/a-module.ts
@@ -1,7 +1,7 @@
 export interface ExportedButNotInExports {
-  aMethod: () => void
+  aMethod(): void
 }
 
 export interface UsedButNotExported {
-  aMethod: () => void
+  aMethod(): void
 }

--- a/test/fixtures/projects/a-ts-project/src/index.ts
+++ b/test/fixtures/projects/a-ts-project/src/index.ts
@@ -14,7 +14,7 @@ export const useDerp = (): void => {
 }
 
 export interface AnExportedInterface {
-  aMethod: () => void
+  aMethod(): void
 }
 
 export type { ExportedButNotInExports } from './a-module.js'

--- a/test/fixtures/projects/an-esm-project/src/types.ts
+++ b/test/fixtures/projects/an-esm-project/src/types.ts
@@ -1,7 +1,7 @@
 export interface ExportedButNotInExports {
-  aMethod: () => void
+  aMethod(): void
 }
 
 export interface UsedButNotExported {
-  aMethod: () => void
+  aMethod(): void
 }


### PR DESCRIPTION
- See https://github.com/ipfs/eslint-config-ipfs/pull/190

BREAKING CHANGE: All interfaces now need to use method signature style rather than property function style

eg:
before
```ts
interface Foo {
  bar: (baz: number) => void
}
```
after
```ts
interface Foo {
  bar(baz: number): void
}
```
