### PR TITLE
fix: add package to eslint parser options

### DIFF
--- a/src/check-project/manifests/typed-cjs.js
+++ b/src/check-project/manifests/typed-cjs.js
@@ -36,7 +36,10 @@ export async function typedCJSManifest (manifest, branchName, repoUrl, homePage 
       'dist'
     ],
     eslintConfig: merge({
-      extends: 'ipfs'
+      extends: 'ipfs',
+      parserOptions: {
+        package: true
+      }
     }, manifest.eslintConfig),
     release: (manifest.scripts?.release?.includes('semantic-release') || manifest.scripts?.release?.includes('aegir release')) ? semanticReleaseConfig(branchName) : undefined
   }, repoUrl, homePage)

--- a/src/check-project/manifests/typed-esm.js
+++ b/src/check-project/manifests/typed-esm.js
@@ -51,6 +51,7 @@ export async function typedESMManifest (manifest, branchName, repoUrl, homePage 
     eslintConfig: merge({
       extends: 'ipfs',
       parserOptions: {
+        package: true,
         sourceType: 'module'
       }
     }, manifest.eslintConfig),

--- a/src/check-project/manifests/typescript.js
+++ b/src/check-project/manifests/typescript.js
@@ -38,6 +38,7 @@ export async function typescriptManifest (manifest, branchName, repoUrl, homePag
     eslintConfig: merge({
       extends: 'ipfs',
       parserOptions: {
+        package: true,
         sourceType: 'module'
       }
     }, manifest.eslintConfig),

--- a/src/check-project/manifests/untyped-cjs.js
+++ b/src/check-project/manifests/untyped-cjs.js
@@ -21,7 +21,10 @@ export async function untypedCJSManifest (manifest, branchName, repoUrl, homePag
       'dist'
     ],
     eslintConfig: merge({
-      extends: 'ipfs'
+      extends: 'ipfs',
+      parserOptions: {
+        package: true
+      }
     }, manifest.eslintConfig),
     release: (manifest.scripts?.release?.includes('semantic-release') || manifest.scripts?.release?.includes('aegir release')) ? semanticReleaseConfig(branchName) : undefined
   }, repoUrl, homePage)

--- a/src/check-project/manifests/untyped-esm.js
+++ b/src/check-project/manifests/untyped-esm.js
@@ -31,6 +31,7 @@ export async function untypedESMManifest (manifest, branchName, repoUrl, homePag
     eslintConfig: merge({
       extends: 'ipfs',
       parserOptions: {
+        package: true,
         sourceType: 'module'
       }
     }, manifest.eslintConfig),


### PR DESCRIPTION
To support linting a file using the nearest config add `package: true`
to the default parser options.