### PR TITLE
fix: set bail defaults correctly

### DIFF
--- a/src/cmds/exec.js
+++ b/src/cmds/exec.js
@@ -28,7 +28,7 @@ export default {
         bail: {
           type: 'boolean',
           describe: '',
-          default: userConfig.build.bundle
+          default: userConfig.exec.bail
         }
       })
   },

--- a/src/cmds/run.js
+++ b/src/cmds/run.js
@@ -28,7 +28,7 @@ export default {
         bail: {
           type: 'boolean',
           describe: '',
-          default: userConfig.build.bundle
+          default: userConfig.run.bail
         }
       })
       .positional('script', {


### PR DESCRIPTION
- noticed some likely leftover copy pasta 
- fix `run --bail` and `exec --bail` defaults