### PR TITLE
fix: disable test coverage again

### DIFF
--- a/src/cmds/test.js
+++ b/src/cmds/test.js
@@ -107,9 +107,9 @@ export default {
    * @param {any} argv
    */
   async handler (argv) {
-    // temporarily disable code coverage on node targets running node 18
-    if (argv.cov && process.version.startsWith('v18.') && argv.target === 'node') {
-      console.warn(kleur.red('!!! Temporarily disabling code coverage - https://github.com/ipfs/aegir/issues/1206\n')) // eslint-disable-line no-console
+    // temporarily disable code coverage on node 18
+    if (argv.cov && process.version.startsWith('v18.')) {
+      console.warn(kleur.red('!!! Temporarily disabling code coverage\n')) // eslint-disable-line no-console
       delete argv.cov
     }
 


### PR DESCRIPTION
This is not fixed, it's still causing larger builds to hang.

Reverts ipfs/aegir#1195