### PR TITLE
fix: do not run `npm --if-present build` on npm cache hit

### DIFF
--- a/actions/cache-node-modules/action.yml
+++ b/actions/cache-node-modules/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: 'echo'
   build_on_cache_fail:
     description: 'Whether you want to run `npm run --if-present build` if there is no cache'
-    require: false
+    required: false
     default: 'true' # defaulting to true to not break any existing users.
   cache_name:
     description: 'Cache name'
@@ -38,9 +38,9 @@ runs:
     - if: steps.cache.outputs.cache-hit != 'true'
       run: npm install
       shell: bash
-    - if: steps.cache.outputs.cache-hit != 'true' && ${{ inputs.build_on_cache_fail }} == 'true'
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.build_on_cache_fail == 'true' }}
       run: npm run --if-present build
       shell: bash
-    - if: steps.cache.outputs.cache-hit != 'true' && ${{ inputs.build }} != 'echo'
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.build != 'echo' }}
       run: ${{ inputs.build }}
       shell: bash


### PR DESCRIPTION
Fixes a regression introduced by #1070.

Essentially you can't include `${{ ... }}` inside regular YAML `if` clauses, you have to have the whole clause inside `${{ ... }}`.

This explains why every monorepo job builds on every run despite the npm/build cache being hit.

For the situation where the build cache exists (run GH action with debug logging turned on to see this sort of thing):

Before:

```
##[debug]Evaluating condition for step: 'run'
##[debug]Evaluating: (success() && format('steps.cache.outputs.cache-hit != ''true'' && {0} == ''true''', inputs.build_on_cache_fail))
##[debug]Evaluating And:
##[debug]..Evaluating success:
##[debug]..=> true
##[debug]..Evaluating format:
##[debug]....Evaluating String:
##[debug]....=> 'steps.cache.outputs.cache-hit != ''true'' && {0} == ''true'''
##[debug]....Evaluating Index:
##[debug]......Evaluating inputs:
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'build_on_cache_fail'
##[debug]....=> 'true'
##[debug]..=> 'steps.cache.outputs.cache-hit != ''true'' && true == ''true'''
##[debug]=> 'steps.cache.outputs.cache-hit != ''true'' && true == ''true'''
##[debug]Expanded: (true && 'steps.cache.outputs.cache-hit != ''true'' && true == ''true''')
##[debug]Result: 'steps.cache.outputs.cache-hit != ''true'' && true == ''true'''
##[debug]Starting: run
```

Essentially it's evaluating `(true && 'steps.cache.outputs.cache-hit != ''true'' && true == ''true''')`, e.g. `(true && string)` which always evaluates to `true`.

After:

```
##[debug]Evaluating condition for step: 'run'
##[debug]Evaluating: (success() && (steps.cache.outputs.cache-hit != 'true') && (inputs.build_on_cache_fail == 'true'))
##[debug]Evaluating And:
##[debug]..Evaluating success:
##[debug]..=> true
##[debug]..Evaluating NotEqual:
##[debug]....Evaluating Index:
##[debug]......Evaluating Index:
##[debug]........Evaluating Index:
##[debug]..........Evaluating steps:
##[debug]..........=> Object
##[debug]..........Evaluating String:
##[debug]..........=> 'cache'
##[debug]........=> Object
##[debug]........Evaluating String:
##[debug]........=> 'outputs'
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'cache-hit'
##[debug]....=> 'true'
##[debug]....Evaluating String:
##[debug]....=> 'true'
##[debug]..=> false
##[debug]=> false
##[debug]Expanded: (true && ('true' != 'true') && (inputs['build_on_cache_fail'] == 'true'))
##[debug]Result: false
```