### PR TITLE
feat: sync packageDocumentation between index.ts and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,9 @@
-# aegir <!-- omit in toc -->
-
 [![ipfs.tech](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech)
 [![Discuss](https://img.shields.io/discourse/https/discuss.ipfs.tech/posts.svg?style=flat-square)](https://discuss.ipfs.tech)
 [![codecov](https://img.shields.io/codecov/c/github/ipfs/aegir.svg?style=flat-square)](https://codecov.io/gh/ipfs/aegir)
 [![CI](https://img.shields.io/github/actions/workflow/status/ipfs/aegir/js-test-and-release.yml?branch=master\&style=flat-square)](https://github.com/ipfs/aegir/actions/workflows/js-test-and-release.yml?query=branch%3Amaster)
 
 > JavaScript project management
-
-## Table of contents <!-- omit in toc -->
-
-- [Install](#install)
-  - [Browser `<script>` tag](#browser-script-tag)
-- [Project Structure](#project-structure)
-- [CLI](#cli)
-- [Configuration](#configuration)
-- [Continuous Integration](#continuous-integration)
-- [Testing helpers](#testing-helpers)
-- [Typescript](#typescript)
-- [Release steps](#release-steps)
-- [API Docs](#api-docs)
-- [License](#license)
-- [Contribute](#contribute)
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -275,7 +275,6 @@
     "mdast-util-gfm-table": "^2.0.0",
     "mdast-util-gfm-task-list-item": "^2.0.0",
     "mdast-util-to-markdown": "^2.0.0",
-    "mdast-util-toc": "^7.0.0",
     "merge-options": "^3.0.4",
     "micromark-extension-gfm": "^3.0.0",
     "micromark-extension-gfm-footnote": "^2.0.0",

--- a/src/check-project/check-monorepo-readme.js
+++ b/src/check-project/check-monorepo-readme.js
@@ -1,8 +1,8 @@
+/* eslint-disable complexity */
 /* eslint-disable no-console */
 
 import path from 'path'
 import fs from 'fs-extra'
-import { toc as makeToc } from 'mdast-util-toc'
 import { APIDOCS } from './readme/api-docs.js'
 import { HEADER } from './readme/header.js'
 import { LICENSE } from './readme/license.js'
@@ -50,105 +50,120 @@ export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, p
   // create basic readme with heading, CI link, etc
   const readme = parseMarkdown(HEADER(pkg, repoOwner, repoName, defaultBranch, ciFile))
 
+  /** @type {import('mdast').RootContent[]} */
+  const header = []
+
+  /** @type {import('mdast').RootContent[]} */
+  const other = []
+
+  /** @type {import('mdast').RootContent[]} */
+  const about = []
+
+  /** @type {import('mdast').RootContent[]} */
+  const footer = []
+
+  let skipBlockHeader = -1
+  let inAboutBlock = false
+  let foundBadges = false
+
   // remove existing header, CI link, etc
+  file.children.forEach((child) => {
+    const rendered = writeMarkdown(child).toLowerCase()
+
+    if (skipBlockHeader > -1 && child.type === 'heading' && child.depth <= skipBlockHeader) {
+      skipBlockHeader = -1
+      inAboutBlock = false
+    }
+
+    if (rendered === `> ${pkg.description.toLowerCase()}\n`) {
+      // skip project description
+      return
+    }
+
+    if (child.type === 'paragraph' && rendered.includes('![ci]')) {
+      // skip badges
+      foundBadges = true
+      return
+    }
+
+    if (child.type === 'heading' && rendered.includes('# about')) {
+      // collect about section
+      skipBlockHeader = child.depth
+      inAboutBlock = true
+      about.push(child)
+      return
+    }
+
+    if (child.type === 'heading' && rendered.includes('# packages')) {
+      // skip packages
+      skipBlockHeader = child.depth
+      return
+    }
+
+    if (child.type === 'heading' && rendered.includes('# api docs')) {
+      // skip api docs
+      skipBlockHeader = child.depth
+      return
+    }
+
+    if (child.type === 'heading' && rendered.includes('# license')) {
+      // skip license
+      skipBlockHeader = child.depth
+      return
+    }
+
+    if (child.type === 'heading' && (rendered.includes('# contribute') || rendered.includes('# contribution'))) {
+      // skip contribute
+      skipBlockHeader = child.depth
+      return
+    }
+
+    if (child.type === 'definition') {
+      footer.push(child)
+      return
+    }
+
+    if (inAboutBlock) {
+      about.push(child)
+      return
+    }
+
+    if (!foundBadges) {
+      header.push(child)
+      return
+    }
+
+    if (skipBlockHeader > -1) {
+      // skip this block
+      return
+    }
+
+    other.push(child)
+  })
+
+  const license = parseMarkdown(LICENSE(pkg, repoOwner, repoName, defaultBranch))
+
   /** @type {import('mdast').Root} */
-  const parsedReadme = {
+  let apiDocs = {
     type: 'root',
     children: []
   }
 
-  let structureIndex = -1
-  let tocIndex = -1
-  let apiDocsIndex = -1
-  let licenseFound = false
-
-  file.children.forEach((child, index) => {
-    const rendered = writeMarkdown(child).toLowerCase()
-
-    if (rendered.includes('https://raw.githubusercontent.com/ipfs/helia/main/assets/helia.png')) {
-      // skip helia logo
-      return
-    }
-
-    if (child.type === 'heading' && (index === 0 || rendered.includes(pkg.name))) {
-      // skip heading
-      return
-    }
-
-    if (child.type === 'paragraph' && (index === 1 || rendered.includes('![ci]'))) {
-      // skip badges
-      return
-    }
-
-    if (child.type === 'blockquote' && tocIndex === -1 && tocIndex === -1) {
-      // skip project overview
-      return
-    }
-
-    if (rendered.includes('## table of')) {
-      // skip toc header
-      tocIndex = index
-      return
-    }
-
-    if (tocIndex !== -1 && index === tocIndex + 1) {
-      // skip toc
-      return
-    }
-
-    if (child.type === 'heading' && rendered.includes('structure')) {
-      // skip structure header
-      structureIndex = index
-      return
-    }
-
-    if (structureIndex !== -1 && index === structureIndex + 1) {
-      // skip structure
-      return
-    }
-
-    if (child.type === 'heading' && rendered.includes('api docs')) {
-      // skip api docs header
-      apiDocsIndex = index
-      return
-    }
-
-    if (apiDocsIndex !== -1 && index === apiDocsIndex + 1) {
-      // skip api docs link
-      return
-    }
-
-    if ((child.type === 'heading' && rendered.includes('license')) || licenseFound) {
-      licenseFound = true
-      return
-    }
-
-    parsedReadme.children.push(child)
-  })
-
-  const license = parseMarkdown(LICENSE(pkg, repoOwner, repoName, defaultBranch))
-  const apiDocs = parseMarkdown(APIDOCS(pkg))
-  const structure = parseMarkdown(STRUCTURE(projectDir, projectDirs))
-
-  parsedReadme.children = [
-    ...structure.children,
-    ...parsedReadme.children,
-    ...apiDocs.children,
-    ...license.children
-  ]
-
-  const toc = makeToc(parsedReadme, {
-    tight: true
-  })
-
-  if (toc.map == null) {
-    throw new Error('Could not create TOC for README.md')
+  if (fs.existsSync(path.join(projectDir, 'typedoc.json')) || pkg.scripts.docs != null) {
+    apiDocs = parseMarkdown(APIDOCS(pkg))
   }
 
+  const structure = parseMarkdown(STRUCTURE(projectDir, projectDirs))
+
   readme.children = [
+    ...header,
     ...readme.children,
-    toc.map,
-    ...parsedReadme.children
+    ...about,
+    ...structure.children,
+    ...other,
+    ...apiDocs.children,
+    ...license.children,
+    ...footer
   ]
 
   await ensureFileHasContents(projectDir, 'README.md', writeMarkdown(readme))

--- a/src/check-project/files/gitignore
+++ b/src/check-project/files/gitignore
@@ -1,8 +1,9 @@
-/node_modules
-/build
-/dist
-/.docs
-/.coverage
-/.vscode
+node_modules
+build
+dist
+.docs
+.coverage
+node_modules
 package-lock.json
 yarn.lock
+.vscode

--- a/src/check-project/readme/header.js
+++ b/src/check-project/readme/header.js
@@ -26,36 +26,6 @@ const BADGES = {
 }
 
 /**
- * @type {Record<string, (pkg: *, repoOwner: string, repoName: string, defaultBranch: string, ciFile: string) => string>}
- */
-const HEADERS = {
-  'ipfs/helia(-.+)?$': (pkg, repoOwner, repoName, defaultBranch, ciFile) => `
-<p align="center">
-  <a href="https://github.com/ipfs/helia" title="Helia">
-    <img src="https://raw.githubusercontent.com/ipfs/helia/main/assets/helia.png" alt="Helia logo" width="300" />
-  </a>
-</p>
-
-# ${pkg.name} <!-- omit in toc -->
-
-${(BADGES[repoOwner] ?? BADGES.default)(repoOwner, repoName, defaultBranch, ciFile).trim()}
-
-> ${pkg.description}
-
-## Table of contents <!-- omit in toc -->
-`,
-  default: (pkg, repoOwner, repoName, defaultBranch, ciFile) => `
-# ${pkg.name} <!-- omit in toc -->
-
-${(BADGES[repoOwner] ?? BADGES.default)(repoOwner, repoName, defaultBranch, ciFile).trim()}
-
-> ${pkg.description}
-
-## Table of contents <!-- omit in toc -->
-`
-}
-
-/**
  * @param {*} pkg
  * @param {string} repoOwner
  * @param {string} repoName
@@ -63,14 +33,9 @@ ${(BADGES[repoOwner] ?? BADGES.default)(repoOwner, repoName, defaultBranch, ciFi
  * @param {string} ciFile
  */
 export const HEADER = (pkg, repoOwner, repoName, defaultBranch, ciFile) => {
-  let generateHeader = HEADERS.default
+  return `
+${(BADGES[repoOwner] ?? BADGES.default)(repoOwner, repoName, defaultBranch, ciFile).trim()}
 
-  for (const [key, fn] of Object.entries(HEADERS)) {
-    if (new RegExp(key, 'm').test(`${repoOwner}/${repoName}`)) {
-      generateHeader = fn
-      break
-    }
-  }
-
-  return generateHeader(pkg, repoOwner, repoName, defaultBranch, ciFile)
+> ${pkg.description}
+`
 }

--- a/src/check-project/readme/install.js
+++ b/src/check-project/readme/install.js
@@ -2,20 +2,25 @@
  * @param {*} pkg
  */
 export const INSTALL = (pkg) => {
-  const nodeInstall = `
-  ## Install
+  if (pkg.exports == null && pkg.main == null && pkg.bin == null) {
+    // this module has no external API, skip installation instructions
+    return ''
+  }
 
-  \`\`\`console
-  $ npm i ${pkg.name}
-  \`\`\`
+  const nodeInstall = `
+## Install
+
+\`\`\`console
+$ npm i ${pkg.name}
+\`\`\`
 `
   const browserInstall = `### Browser \`<script>\` tag
 
-  Loading this module through a script tag will make it's exports available as \`${nameToGlobalSymbol(pkg.name)}\` in the global namespace.
+Loading this module through a script tag will make it's exports available as \`${nameToGlobalSymbol(pkg.name)}\` in the global namespace.
 
-  \`\`\`html
-  <script src="https://unpkg.com/${pkg.name}/dist/index.min.js"></script>
-  \`\`\`
+\`\`\`html
+<script src="https://unpkg.com/${pkg.name}/dist/index.min.js"></script>
+\`\`\`
 `
   const scripts = pkg.scripts ?? {}
 

--- a/src/check-project/readme/structure.js
+++ b/src/check-project/readme/structure.js
@@ -18,7 +18,7 @@ export const STRUCTURE = (monorepoDir, projectDirs) => {
   }
 
   return `
-## Structure
+## Packages
 
 ${Object.entries(packages).map(([key, value]) => {
   return `* [\`${key}\`](.${key}) ${value}`

--- a/src/docs.js
+++ b/src/docs.js
@@ -54,6 +54,8 @@ const docs = async (ctx, task) => {
       fromAegir('src/docs/type-indexer-plugin.js'),
       '--plugin',
       'typedoc-plugin-mdn-links',
+      '--plugin',
+      fromAegir('src/docs/readme-updater-plugin.js'),
       ...forwardOptions
     ],
     {

--- a/src/docs/readme-updater-plugin.js
+++ b/src/docs/readme-updater-plugin.js
@@ -1,0 +1,197 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import * as td from 'typedoc'
+import { parseMarkdown, writeMarkdown } from '../check-project/readme/utils.js'
+import { isMonorepoParent, parseProjects, pkg } from '../utils.js'
+
+/**
+ * A plugin that updates the `About` section of a README with the rendered
+ * contents of a `@packageDocumentation` tag.
+ *
+ * @param {td.Application} app
+ */
+export function load (app) {
+  /** @type {Record<string, any>} */
+  let projects = {}
+
+  if (isMonorepoParent) {
+    projects = parseProjects(process.cwd(), pkg.workspaces)
+  }
+
+  // when rendering has finished, work out which UrlMappings refer to the index
+  // pages of the current module or monorepo packages
+  app.renderer.on(td.RendererEvent.END, (/** @type {td.RendererEvent} */ evt) => {
+    const urlMappings = evt.urls?.filter(urlMapping => {
+      // skip anything without a model-level comment
+      if (urlMapping.model?.comment == null) {
+        return false
+      }
+
+      // single-module repo
+      if (urlMapping.url === 'modules.html') {
+        return true
+      }
+
+      // mono-repo and the model name matches a package name
+      if (isMonorepoParent && projects[urlMapping.model.name] != null) {
+        return true
+      }
+
+      return false
+    }).map(urlMapping => {
+      if (urlMapping.model?.comment == null) {
+        throw new Error('Model comment was null')
+      }
+
+      if (isMonorepoParent) {
+        return {
+          comment: urlMapping.model.comment,
+          manifestPath: path.join(projects[urlMapping.model.name].dir, 'package.json'),
+          readmePath: path.join(projects[urlMapping.model.name].dir, 'README.md')
+        }
+      }
+
+      return {
+        comment: urlMapping.model.comment,
+        manifestPath: path.join(process.cwd(), 'package.json'),
+        readmePath: path.join(process.cwd(), 'README.md')
+      }
+    })
+
+    urlMappings?.forEach(urlMapping => updateModule(urlMapping.comment, urlMapping.manifestPath, urlMapping.readmePath, app))
+  })
+}
+
+/**
+ * Turn the comment into markdown
+ *
+ * @param {td.Models.Comment} comment
+ * @param {string} manifestPath
+ * @param {string} readmePath
+ * @param {td.Application} app
+ * @returns {void}
+ */
+function updateModule (comment, manifestPath, readmePath, app) {
+  const about = `
+## About
+
+${
+  comment.summary
+    .map(item => item.text)
+    .join('')
+}
+${
+  comment.blockTags
+        .map(item => {
+          if (item.tag === '@example') {
+            return `
+### Example
+
+${
+  item.content
+    .map(item => item.text)
+    .join('')
+}
+`
+        }
+
+        app.logger.warn(`Unknown block tag: ${item.tag}`)
+
+        return ''
+      })
+}
+`.trim()
+
+  try {
+    updateReadme(about, manifestPath, readmePath, app)
+  } catch (/** @type {any} */ err) {
+    app.logger.error(`Could not update README about section: ${err.stack}`)
+  }
+}
+
+/**
+ * Accept a markdown string and add it to the README, replacing any existing
+ * "About" section
+ *
+ * @param {string} aboutMd
+ * @param {string} manifestPath
+ * @param {string} readmePath
+ * @param {td.Application} app
+ * @returns {void}
+ */
+function updateReadme (aboutMd, manifestPath, readmePath, app) {
+  if (!fs.existsSync(readmePath)) {
+    app.logger.error(`Could not read readme from ${readmePath}`)
+  }
+
+  const readmeContents = fs.readFileSync(readmePath, {
+    encoding: 'utf-8'
+  })
+    // replace the magic OPTION+SPACE character that messes up headers
+    .replaceAll(' ', ' ')
+
+  if (!fs.existsSync(manifestPath)) {
+    app.logger.error(`Could not read manifest from ${manifestPath}`)
+  }
+
+  const manifestContents = fs.readFileSync(manifestPath, {
+    encoding: 'utf-8'
+  })
+  const manifest = JSON.parse(manifestContents)
+
+  // parse the project's readme file
+  const readme = parseMarkdown(readmeContents)
+  const about = parseMarkdown(aboutMd)
+
+  // remove existing header, CI link, etc
+  /** @type {import('mdast').Root} */
+  const parsedReadme = {
+    type: 'root',
+    children: []
+  }
+
+  let foundAbout = false
+  let aboutHeadingLevel = -1
+
+  readme.children.forEach((child, index) => {
+    const rendered = writeMarkdown(child).toLowerCase()
+
+    if (child.type === 'blockquote' && rendered === `> ${manifest.description.toLowerCase()}\n`) {
+      // insert the `About` section beneath the project description
+      parsedReadme.children.push(
+        child,
+        ...about.children
+      )
+
+      return
+    }
+
+    if (child.type === 'heading' && rendered.includes('# about')) {
+      // we have found an existing `About` section - skip all content until we
+      // hit another heading equal or higher depth than `About
+      foundAbout = true
+      aboutHeadingLevel = child.depth
+
+      // skip about
+      return
+    }
+
+    if (foundAbout) {
+      if (child.type === 'heading' && child.depth <= aboutHeadingLevel) {
+        foundAbout = false
+      } else {
+        // skip all content until we hit another heading equal or higher depth
+        // than `About`
+        return
+      }
+    }
+
+    parsedReadme.children.push(child)
+  })
+
+  const updatedReadmeContents = writeMarkdown(parsedReadme)
+
+  fs.writeFileSync(readmePath, updatedReadmeContents, {
+    encoding: 'utf-8'
+  })
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -328,7 +328,7 @@ export async function everyMonorepoProject (projectDir, fn) {
   }
 
   /** @type {Record<string, Project>} */
-  const projects = await parseProjects(projectDir, workspaces)
+  const projects = parseProjects(projectDir, workspaces)
 
   checkForCircularDependencies(projects)
 


### PR DESCRIPTION
Adds a typedoc plugin to extract module comments (e.g. `@packageDocumentation`) and add them to the README in an `About` section when `npm run docs` is run.

It will also keep them in sync using the source code as a source of truth.