### PR TITLE
fix: join readme example descriptions with ''

### DIFF
--- a/src/docs/readme-updater-plugin.js
+++ b/src/docs/readme-updater-plugin.js
@@ -99,6 +99,7 @@ ${
 
         return ''
       })
+      .join('')
 }
 `.trim()
 


### PR DESCRIPTION
Otherwise comma+spaces are inserted as the default join character.