### PR TITLE
fix: if a test run looks like it's hung during coverage, kill it

### DIFF
--- a/src/cmds/test.js
+++ b/src/cmds/test.js
@@ -100,6 +100,11 @@ export default {
           describe: 'Enable coverage output. Output is already in Istanbul JSON format and can be uploaded directly to codecov.',
           type: 'boolean',
           default: userConfig.test.cov
+        },
+        covTimeout: {
+          describe: 'How long to wait for coverage collection. Workaround for https://github.com/ipfs/aegir/issues/1206',
+          type: 'number',
+          default: userConfig.test.covTimeout
         }
       })
   },

--- a/src/config/user.js
+++ b/src/config/user.js
@@ -25,6 +25,7 @@ const defaults = {
     bail: false,
     progress: false,
     cov: false,
+    covTimeout: 60000,
     browser: {
       config: {
         buildConfig: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,6 +237,10 @@ interface TestOptions {
    */
   cov: boolean
   /**
+   * How long to wait for collecting code coverage. Workaround for @see https://github.com/ipfs/aegir/issues/1206
+   */
+  covTimeout: number
+  /**
    * Runner enviroment
    */
   runner: 'node' | 'browser' | 'webworker' | 'electron-main' | 'electron-renderer' | 'react-native-android' | 'react-native-ios'


### PR DESCRIPTION
Watch for test output that looks like the end of a successful test run - if collecting coverage takes too long, kill the process but do not cause the test run to fail.

Temporary workaround for https://github.com/ipfs/aegir/issues/1206