### PR TITLE
fix: use example title if it is available

### DIFF
--- a/src/docs/readme-updater-plugin.js
+++ b/src/docs/readme-updater-plugin.js
@@ -85,7 +85,7 @@ ${
         .map(item => {
           if (item.tag === '@example') {
             return `
-## Example
+## Example${item.name ? ` - ${item.name}` : ''}
 
 ${
   item.content


### PR DESCRIPTION
TypeDoc was updated recently to parse the example title correctly so use if it is available