### PR TITLE
fix: skip build in CI

### DIFF
--- a/src/config/user.js
+++ b/src/config/user.js
@@ -15,7 +15,9 @@ const defaults = {
   debug: false,
   // test cmd options
   test: {
-    build: true,
+    // no need to build before testing in CI since we build after installing
+    // deps so building again is redundant
+    build: process.env.CI == null,
     runner: 'node',
     target: ['node', 'browser', 'webworker'],
     watch: false,


### PR DESCRIPTION
In CI we always build after an install, which happens before testing so we can skip the build step since all build output should have been cached.