### PR TITLE
feat: support cname for docs publishing

### DIFF
--- a/src/cmds/docs.js
+++ b/src/cmds/docs.js
@@ -55,6 +55,11 @@ export default {
           type: 'string',
           describe: 'Where to build the documentation',
           default: userConfig.docs.directory
+        },
+        cname: {
+          type: 'string',
+          describe: 'A custom domain pointed at the gh-pages branch',
+          default: userConfig.docs.cname
         }
       })
   },

--- a/src/docs.js
+++ b/src/docs.js
@@ -120,6 +120,7 @@ async function findMonorepoEntryPoints () {
  * @property {string} PublishDocsConfig.email
  * @property {string} PublishDocsConfig.message
  * @property {string} PublishDocsConfig.directory
+ * @property {string} [PublishDocsConfig.cname]
  */
 
 /**
@@ -138,7 +139,8 @@ const publishDocs = async (config) => {
       user: {
         name: config.user,
         email: config.email
-      }
+      },
+      cname: config.cname
     }
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,10 @@ interface DocsOptions {
    * Where to build the documentation
    */
   directory: string
+  /**
+   * If set a CNAME file will be written with a custom domain
+   */
+  cname?: string
 }
 
 interface DocsVerifierOptions {


### PR DESCRIPTION
Expose the `cname` option from `gh-pages` to support publishing docs on a custom domain.