### PR TITLE
fix: add missing @types/mdast dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,6 +325,7 @@
     "@types/fs-extra": "^11.0.1",
     "@types/gh-pages": "^6.1.0",
     "@types/listr": "^0.14.2",
+    "@types/mdast": "^4.0.3",
     "@types/pascalcase": "^1.0.0",
     "@types/polka": "^0.5.2",
     "@types/prompt": "^1.1.2",


### PR DESCRIPTION
resolves multiple errors of error TS2307: Cannot find module 'mdast' or its corresponding type declarations.
