### PR TITLE
fix: point to esbuild bundle analysis tool instead of bundlebuddy

### DIFF
--- a/src/build/index.js
+++ b/src/build/index.js
@@ -95,8 +95,9 @@ const tasks = new Listr([
         const maxsize = bytes(ctx.bundlesizeMax)
         const diff = gzip - maxsize
 
-        task.output = 'Use https://www.bundle-buddy.com/ to load "./dist/stats.json".'
-        task.output = `Check previous sizes in https://bundlephobia.com/result?p=${pkg.name}@${pkg.version}`
+        task.output = 'Use https://esbuild.github.io/analyze/ to load "./dist/stats.json".'
+        // bundlephobia doesn't support exports maps properly
+        // task.output = `Check previous sizes in https://bundlephobia.com/result?p=${pkg.name}@${pkg.version}`
 
         if (diff > 0) {
           throw new Error(`${bytes(gzip)} (▲${bytes(diff)} / ${bytes(maxsize)})`)


### PR DESCRIPTION
It's prettier and works better.