### PR TITLE
fix: update check-config command to handle release-please monorepos

### DIFF
--- a/src/check-project/check-licence-files.js
+++ b/src/check-project/check-licence-files.js
@@ -11,9 +11,14 @@ import {
  * @param {string} projectDir
  */
 export async function checkLicenseFiles (projectDir) {
-  console.info('Check license files')
-
   const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
+
+  if (pkg.private === true) {
+    console.info('Private module found, skipping licence file check')
+    return
+  }
+
+  console.info('Check license files')
 
   if (pkg.license !== 'Apache-2.0 OR MIT') {
     throw new Error(`Incorrect license field - found '${pkg.license}', expected 'Apache-2.0 OR MIT'`)

--- a/src/check-project/check-monorepo-readme.js
+++ b/src/check-project/check-monorepo-readme.js
@@ -28,7 +28,7 @@ export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, p
     throw new Error(`Could not parse repo owner & name from ${repoUrl}`)
   }
 
-  console.info('Check README files')
+  console.info('Check monorepo README files')
 
   const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
 

--- a/src/check-project/check-readme.js
+++ b/src/check-project/check-readme.js
@@ -27,9 +27,14 @@ export async function checkReadme (projectDir, repoUrl, defaultBranch, ciFile, r
     throw new Error(`Could not parse repo owner & name from ${repoUrl}`)
   }
 
-  console.info('Check README files')
-
   const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
+
+  if (pkg.private) {
+    console.info('Private module found, skipping README file check')
+    return
+  }
+
+  console.info('Check README files')
 
   const readmePath = path.join(projectDir, 'README.md')
   let readmeContents = ''

--- a/src/check-project/check-typedoc-files.js
+++ b/src/check-project/check-typedoc-files.js
@@ -3,6 +3,9 @@
 import path from 'path'
 import fs from 'fs-extra'
 import {
+  pkg
+} from '../utils.js'
+import {
   ensureFileHasContents
 } from './utils.js'
 
@@ -11,15 +14,22 @@ import {
  * @param {boolean} isTypescriptProject
  */
 export async function checkTypedocFiles (projectDir, isTypescriptProject) {
-  console.info('Check typedoc files')
+  const manifest = fs.readJSONSync(path.join(projectDir, 'package.json'))
 
-  const pkg = fs.readJSONSync(path.join(projectDir, 'package.json'))
-
-  if (pkg.exports == null) {
+  if (manifest.scripts.docs == null && pkg.scripts.docs == null) {
+    console.info('No "docs" npm script found, skipping typedoc.json check')
     return
   }
 
-  const entryPoints = Object.values(pkg.exports)
+  if (manifest.exports == null) {
+    console.info('No exports map found, skipping typedoc.json check')
+
+    return
+  }
+
+  console.info('Check typedoc files')
+
+  const entryPoints = Object.values(manifest.exports)
     .map(e => {
       const path = e.import
 

--- a/src/check-project/manifests/typescript.js
+++ b/src/check-project/manifests/typescript.js
@@ -45,7 +45,7 @@ export async function typescriptManifest (manifest, branchName, repoUrl, homePag
     release: (manifest.scripts?.release?.includes('semantic-release') || manifest.scripts?.release?.includes('aegir release')) ? semanticReleaseConfig(branchName) : undefined
   }, repoUrl, homePage)
 
-  if (Object.keys(proposedManifest.exports).length > 1) {
+  if (proposedManifest.exports != null && Object.keys(proposedManifest.exports).length > 1) {
     console.info('Multiple exports detected')
 
     proposedManifest.typesVersions = {

--- a/src/check-project/utils.js
+++ b/src/check-project/utils.js
@@ -233,7 +233,7 @@ export function sortManifest (manifest) {
  * @param {string} homePage
  */
 export function constructManifest (manifest, manifestFields, repoUrl, homePage = repoUrl) {
-  return {
+  const output = {
     name: manifest.name,
     version: manifest.version,
     description: manifest.description,
@@ -262,6 +262,17 @@ export function constructManifest (manifest, manifestFields, repoUrl, homePage =
     optionalDependencies: manifest.optionalDependencies,
     bundledDependencies: manifest.bundledDependencies
   }
+
+  // remove publish-related fields if this module is not published
+  if (manifest.private === true) {
+    output.publishConfig = undefined
+    output.files = undefined
+    output.types = undefined
+    output.typesVersions = undefined
+    output.exports = undefined
+  }
+
+  return output
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -272,9 +272,25 @@ export const isTypedCJS = isCJS && hasMain && hasTypes
 export const isUntypedCJS = isCJS && hasMain
 
 export const isMonorepoProject = (dir = process.cwd()) => {
-  const parentManifestPath = path.resolve(dir, '..', '..', 'package.json')
+  const cwd = path.resolve(dir, '..')
+  const manifest = readPackageUpSync({
+    cwd
+  })
 
-  return Boolean(fs.existsSync(parentManifestPath) && fs.readJSONSync(parentManifestPath).workspaces)
+  return manifest?.packageJson.workspaces != null
+}
+
+export const usesReleasePlease = (dir = process.cwd()) => {
+  try {
+    const mainYmlPath = path.resolve(dir, '.github', 'workflows', 'main.yml')
+    const contents = fs.readFileSync(mainYmlPath, {
+      encoding: 'utf-8'
+    })
+
+    return contents.includes('uses: google-github-actions/release-please-action')
+  } catch {
+    return false
+  }
 }
 
 /**


### PR DESCRIPTION
Release-please updates sibling deps to the latest patch release so don't clobber those changes when running `npx aegir check-project`.

Also skip adding release config to modules that have `"private": true` in their `package.json`.