### PR TITLE
fix: update patch deps during check-project

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,6 +268,7 @@
     "globby": "^14.0.0",
     "is-plain-obj": "^4.1.0",
     "kleur": "^4.1.4",
+    "latest-version": "^8.0.0",
     "lilconfig": "^3.0.0",
     "listr": "~0.14.2",
     "mdast-util-from-markdown": "^2.0.0",


### PR DESCRIPTION
To ensure people with lockfiles get the latest version of deps, update patch versions during `check-project`.