### PR TITLE
fix: add note to readmes about editing index.ts instead

### DIFF
--- a/src/check-project/check-monorepo-readme.js
+++ b/src/check-project/check-monorepo-readme.js
@@ -70,6 +70,11 @@ export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, p
   file.children.forEach((child) => {
     const rendered = writeMarkdown(child).toLowerCase()
 
+    if (child.type === 'heading' && rendered.includes(pkg.name)) {
+      // skip heading
+      return
+    }
+
     if (skipBlockHeader > -1 && child.type === 'heading' && child.depth <= skipBlockHeader) {
       skipBlockHeader = -1
       inAboutBlock = false

--- a/src/check-project/check-readme.js
+++ b/src/check-project/check-readme.js
@@ -74,6 +74,11 @@ export async function checkReadme (projectDir, repoUrl, defaultBranch, ciFile, r
   file.children.forEach((child) => {
     const rendered = writeMarkdown(child).toLowerCase()
 
+    if (child.type === 'heading' && rendered.includes(pkg.name)) {
+      // skip heading
+      return
+    }
+
     if (skipBlockHeader > -1 && child.type === 'heading' && child.depth <= skipBlockHeader) {
       skipBlockHeader = -1
       inAboutBlock = false

--- a/src/check-project/index.js
+++ b/src/check-project/index.js
@@ -145,7 +145,7 @@ async function processMonorepo (projectDir, manifest, branchName, repoUrl, ciFil
   await alignMonorepoProjectDependencies(projectDirs)
   await configureMonorepoProjectReferences(projectDirs)
 
-  let proposedManifest = await monorepoManifest(manifest, repoUrl)
+  let proposedManifest = await monorepoManifest(manifest, repoUrl, repoUrl, branchName)
   proposedManifest = sortManifest(proposedManifest)
 
   await ensureFileHasContents(projectDir, 'package.json', JSON.stringify(proposedManifest, null, 2))
@@ -378,6 +378,7 @@ async function processModule (projectDir, manifest, branchName, repoUrl, homePag
   // 5. CJS, no types
   let untypedCJS = cjs && hasMain
 
+  /** @type any */
   let proposedManifest = {}
 
   if (!typescript && !typedESM && !typedCJS && !untypedCJS) {
@@ -427,6 +428,12 @@ async function processModule (projectDir, manifest, branchName, repoUrl, homePag
     proposedManifest = await untypedCJSManifest(manifest, branchName, repoUrl, homePage)
   } else {
     throw new Error('Cannot determine project type')
+  }
+
+  // remove release config from monorepo projects as multi-semantic-release
+  // wants it defined in the root manifest
+  if (rootManifest != null) {
+    proposedManifest.release = undefined
   }
 
   proposedManifest = sortManifest(proposedManifest)

--- a/src/check-project/manifests/monorepo.js
+++ b/src/check-project/manifests/monorepo.js
@@ -1,3 +1,4 @@
+import { semanticReleaseConfig } from '../semantic-release-config.js'
 import {
   sortFields,
   constructManifest
@@ -6,11 +7,18 @@ import {
 /**
  * @param {any} manifest
  * @param {string} repoUrl
- * @param {string} [homePage]
+ * @param {string} homePage
+ * @param {string} branchName
  */
-export async function monorepoManifest (manifest, repoUrl, homePage = repoUrl) {
+export async function monorepoManifest (manifest, repoUrl, homePage, branchName) {
   let proposedManifest = constructManifest(manifest, {
-    private: true
+    private: true,
+    release: (
+      Object.values(manifest.scripts ?? {})
+        .some(script => script.includes('semantic-release') || script.includes('aegir release'))
+    )
+      ? semanticReleaseConfig(branchName)
+      : undefined
   }, repoUrl, homePage)
 
   const rest = {

--- a/src/check-project/readme/header.js
+++ b/src/check-project/readme/header.js
@@ -34,6 +34,8 @@ const BADGES = {
  */
 export const HEADER = (pkg, repoOwner, repoName, defaultBranch, ciFile) => {
   return `
+# ${pkg.name}
+
 ${(BADGES[repoOwner] ?? BADGES.default)(repoOwner, repoName, defaultBranch, ciFile).trim()}
 
 > ${pkg.description}

--- a/src/docs/readme-updater-plugin.js
+++ b/src/docs/readme-updater-plugin.js
@@ -108,6 +108,21 @@ function updateModule (comment, manifestPath, readmePath, app) {
   const about = `
 # About
 
+<!--
+
+!IMPORTANT!
+
+Everything in this README between "# About" and "# Install" is automatically
+generated and will be overwritten the next time the doc generator is run.
+
+To make changes to this section, please update the @packageDocumentation section
+of src/index.js or src/index.ts
+
+To experiment with formatting, please run "npm run docs" from the root of this
+repo and examine the changes made.
+
+-->
+
 ${
   comment.summary
     .map(item => item.text)


### PR DESCRIPTION
To prevent people opening PRs that update READMEs when they will be generated, add a comment to the README pointing people in the right direction.