### PR TITLE
fix: update to actions/cache@v4

### DIFF
--- a/actions/cache-node-modules/action.yml
+++ b/actions/cache-node-modules/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     # Windows I/O is so slow it's faster to just install the deps every time
     - if: ${{ runner.os != 'Windows' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache
       with:
         path: |


### PR DESCRIPTION
Updates to [actions/cache@v4](https://github.com/actions/cache/releases/tag/v4.0.0) which among other things uses Node.js 20 so silences all the warnings about Node.js 16 still being used.