### PR TITLE
fix: use absolute links in generated readme

### DIFF
--- a/src/check-project/check-monorepo-readme.js
+++ b/src/check-project/check-monorepo-readme.js
@@ -15,11 +15,12 @@ import {
 /**
  * @param {string} projectDir
  * @param {string} repoUrl
+ * @param {string} webRoot
  * @param {string} defaultBranch
  * @param {string[]} projectDirs
  * @param {string} ciFile
  */
-export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, projectDirs, ciFile) {
+export async function checkMonorepoReadme (projectDir, repoUrl, webRoot, defaultBranch, projectDirs, ciFile) {
   const repoParts = repoUrl.split('/')
   const repoName = repoParts.pop()
   const repoOwner = repoParts.pop()
@@ -146,7 +147,7 @@ export async function checkMonorepoReadme (projectDir, repoUrl, defaultBranch, p
     other.push(child)
   })
 
-  const license = parseMarkdown(LICENSE(pkg, repoOwner, repoName, defaultBranch))
+  const license = parseMarkdown(LICENSE(pkg, repoOwner, repoName, webRoot, defaultBranch))
 
   /** @type {import('mdast').Root} */
   let apiDocs = {

--- a/src/check-project/check-readme.js
+++ b/src/check-project/check-readme.js
@@ -14,11 +14,12 @@ import {
 /**
  * @param {string} projectDir
  * @param {string} repoUrl
+ * @param {string} webRoot
  * @param {string} defaultBranch
  * @param {string} ciFile
  * @param {any} [rootManifest]
  */
-export async function checkReadme (projectDir, repoUrl, defaultBranch, ciFile, rootManifest) {
+export async function checkReadme (projectDir, repoUrl, webRoot, defaultBranch, ciFile, rootManifest) {
   const repoParts = repoUrl.split('/')
   const repoName = repoParts.pop()
   const repoOwner = repoParts.pop()
@@ -162,7 +163,7 @@ export async function checkReadme (projectDir, repoUrl, defaultBranch, ciFile, r
     apiDocs = parseMarkdown(APIDOCS(pkg, rootManifest))
   }
 
-  const license = parseMarkdown(LICENSE(pkg, repoOwner, repoName, defaultBranch))
+  const license = parseMarkdown(LICENSE(pkg, repoOwner, repoName, webRoot, defaultBranch))
 
   readme.children = [
     ...header,

--- a/src/check-project/readme/license.js
+++ b/src/check-project/readme/license.js
@@ -1,14 +1,14 @@
 /**
- * @type {Record<string, (repoOwner: string, repoName: string, defaultBranch: string) => string>}
+ * @type {Record<string, (repoOwner: string, repoName: string, repoUrl: string, defaultBranch: string) => string>}
  */
 const licenses = {
-  ipfs: (repoOwner, repoName, defaultBranch) => `
+  ipfs: (repoOwner, repoName, webRoot, defaultBranch) => `
 # License
 
 Licensed under either of
 
-  * Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / http://www.apache.org/licenses/LICENSE-2.0)
-  * MIT ([LICENSE-MIT](LICENSE-MIT) / http://opensource.org/licenses/MIT)
+  * Apache 2.0, ([LICENSE-APACHE](${webRoot.replace('/tree/', '/blob/')}/LICENSE-APACHE) / http://www.apache.org/licenses/LICENSE-2.0)
+  * MIT ([LICENSE-MIT](${webRoot.replace('/tree/', '/blob/')}/LICENSE-MIT) / http://opensource.org/licenses/MIT)
 
 # Contribute
 
@@ -22,13 +22,13 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 [![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)
 `,
-  default: (repoOwner, repoName, defaultBranch) => `
+  default: (repoOwner, repoName, webRoot, defaultBranch) => `
 # License
 
 Licensed under either of
 
-  * Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / http://www.apache.org/licenses/LICENSE-2.0)
-  * MIT ([LICENSE-MIT](LICENSE-MIT) / http://opensource.org/licenses/MIT)
+  * Apache 2.0, ([LICENSE-APACHE](${webRoot.replace('/tree/', '/blob/')}/LICENSE-APACHE) / http://www.apache.org/licenses/LICENSE-2.0)
+  * MIT ([LICENSE-MIT](${webRoot.replace('/tree/', '/blob/')}/LICENSE-MIT) / http://opensource.org/licenses/MIT)
 
 # Contribution
 
@@ -40,8 +40,9 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
  * @param {*} pkg
  * @param {string} repoOwner
  * @param {string} repoName
+ * @param {string} webRoot
  * @param {string} defaultBranch
  */
-export const LICENSE = (pkg, repoOwner, repoName, defaultBranch) => {
-  return (licenses[repoOwner] ?? licenses.default)(repoOwner, repoName, defaultBranch)
+export const LICENSE = (pkg, repoOwner, repoName, webRoot, defaultBranch) => {
+  return (licenses[repoOwner] ?? licenses.default)(repoOwner, repoName, webRoot, defaultBranch)
 }


### PR DESCRIPTION
To prevent broken links in api docs, use absolute links in generated readme files.