### PR TITLE
fix: do not escape GitHub alerts in readmes

### DIFF
--- a/src/docs/readme-updater-plugin.js
+++ b/src/docs/readme-updater-plugin.js
@@ -237,7 +237,15 @@ function updateReadme (aboutMd, manifestPath, readmePath, app) {
     parsedReadme.children.push(child)
   })
 
-  const updatedReadmeContents = writeMarkdown(parsedReadme)
+  let updatedReadmeContents = writeMarkdown(parsedReadme)
+
+  // workaround for https://github.com/syntax-tree/mdast-util-to-markdown/issues/61
+  updatedReadmeContents = updatedReadmeContents
+    .replaceAll('\\[!NOTE]', '[!NOTE]')
+    .replaceAll('\\[!TIP]', '[!TIP]')
+    .replaceAll('\\[!IMPORTANT]', '[!IMPORTANT]')
+    .replaceAll('\\[!WARNING]', '[!WARNING]')
+    .replaceAll('\\[!CAUTION]', '[!CAUTION]')
 
   fs.writeFileSync(readmePath, updatedReadmeContents, {
     encoding: 'utf-8'


### PR DESCRIPTION
Workaround for https://github.com/syntax-tree/mdast-util-to-markdown/issues/61