### PR TITLE
feat: move tsc linter rules to eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "env-paths": "^3.0.0",
     "esbuild": "^0.20.0",
     "eslint": "^8.31.0",
-    "eslint-config-ipfs": "^6.0.0",
+    "eslint-config-ipfs": "^7.0.0",
     "eslint-plugin-etc": "^2.0.2",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-jsdoc": "^48.0.2",

--- a/src/config/tsconfig.aegir.json
+++ b/src/config/tsconfig.aegir.json
@@ -21,11 +21,6 @@
         // module resolution
         "esModuleInterop": true,
         "moduleResolution": "node",
-        // linter checks
-        "noImplicitReturns": false,
-        "noFallthroughCasesInSwitch": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": false,
         // advanced
         "verbatimModuleSyntax": true,
         "forceConsistentCasingInFileNames": true,

--- a/test/fixtures/dependency-check/fail-unused/index.js
+++ b/test/fixtures/dependency-check/fail-unused/index.js
@@ -1,3 +1,2 @@
 /* eslint-disable no-unused-vars */
-// @ts-expect-error unused
 import { execa } from 'execa'

--- a/test/fixtures/dependency-check/ts-fail/src/index.ts
+++ b/test/fixtures/dependency-check/ts-fail/src/index.ts
@@ -1,4 +1,3 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-// @ts-expect-error unused
 import { execa } from 'execa'
 import './other.js'

--- a/test/fixtures/dependency-check/ts-pass/src/index.ts
+++ b/test/fixtures/dependency-check/ts-pass/src/index.ts
@@ -1,3 +1,2 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-// @ts-expect-error unused
 import { execa } from 'execa'


### PR DESCRIPTION
- Resolves https://github.com/ipfs/aegir/issues/1459
- Since all relevant typescript linter rules are now incorporated in the latest eslint-config-ipfs, we can drop them from our tsconfig.