### PR TITLE
fix: dep-check jsx/tsx files

### DIFF
--- a/src/dependency-check.js
+++ b/src/dependency-check.js
@@ -41,7 +41,9 @@ const tasks = new Listr(
         const productionOnlyResult = await depcheck(cwd(), {
           parsers: {
             '**/*.js': depcheck.parser.es6,
+            '**/*.jsx': depcheck.parser.jsx,
             '**/*.ts': depcheck.parser.typescript,
+            '**/*.tsx': depcheck.parser.typescript,
             '**/*.cjs': depcheck.parser.es6,
             '**/*.mjs': depcheck.parser.es6
           },
@@ -84,7 +86,9 @@ const tasks = new Listr(
         const devlopmentOnlyResult = await depcheck(cwd(), {
           parsers: {
             '**/*.js': depcheck.parser.es6,
+            '**/*.jsx': depcheck.parser.jsx,
             '**/*.ts': depcheck.parser.typescript,
+            '**/*.tsx': depcheck.parser.typescript,
             '**/*.cjs': depcheck.parser.es6,
             '**/*.mjs': depcheck.parser.es6
           },


### PR DESCRIPTION
Adds parser config for `.jsx` and `.tsx` to allow checking for unused dependencies.