### PR TITLE
fix: use semantic-release beta release

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
     "react-native-test-runner": "^5.0.0",
     "read-pkg-up": "^11.0.0",
     "rimraf": "^5.0.0",
-    "semantic-release": "^23.0.0",
+    "semantic-release": "24.0.0-beta.2",
     "semantic-release-monorepo": "^8.0.2",
     "semver": "^7.3.8",
     "source-map-support": "^0.5.20",
@@ -339,5 +339,8 @@
     "fs": false,
     "./utils/fixtures.js": "./utils/fixtures.browser.js",
     "./utils/resolve.js": "./utils/resolve.browser.js"
+  },
+  "overrides": {
+    "semantic-release": "24.0.0-beta.2"
   }
 }


### PR DESCRIPTION
Fixes the breakage from the latest commit analyzer release.

Refs: https://github.com/semantic-release/release-notes-generator/issues/633