### PR TITLE
fix: pin eslint-plugin-jsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
     "eslint-config-ipfs": "^7.0.0",
     "eslint-plugin-etc": "^2.0.2",
     "eslint-plugin-import": "^2.18.0",
-    "eslint-plugin-jsdoc": "^48.0.2",
+    "eslint-plugin-jsdoc": "48.8.3",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "execa": "^8.0.1",


### PR DESCRIPTION
The latest `eslint-plugin-jsdoc` broke rule resolution, pin until https://github.com/gajus/eslint-plugin-jsdoc/issues/1277 is fixed.