### PR TITLE
fix: override playwright core version

### DIFF
--- a/package.json
+++ b/package.json
@@ -339,5 +339,8 @@
     "fs": false,
     "./utils/fixtures.js": "./utils/fixtures.browser.js",
     "./utils/resolve.js": "./utils/resolve.browser.js"
+  },
+  "overrides": {
+    "playwright-core": "1.48.0"
   }
 }


### PR DESCRIPTION
Playwright-core is breaking all chrome testing after the `1.49.0` release so override the resolved version to `1.48.0`.

This can be reverted after https://github.com/hugomrdias/playwright-test/pull/685 is merged.