### PR TITLE
fix: revert "fix: override playwright core version"

### DIFF
--- a/package.json
+++ b/package.json
@@ -339,8 +339,5 @@
     "fs": false,
     "./utils/fixtures.js": "./utils/fixtures.browser.js",
     "./utils/resolve.js": "./utils/resolve.browser.js"
-  },
-  "overrides": {
-    "playwright-core": "1.48.0"
   }
 }


### PR DESCRIPTION
Reverts ipfs/aegir#1679

Doesn't work unless `overrides` is in the top level project.