### PR TITLE
fix: ignore module-not-found errors in doc-check

### DIFF
--- a/src/build/index.js
+++ b/src/build/index.js
@@ -93,6 +93,11 @@ const tasks = new Listr([
       if (ctx.bundlesize) {
         const gzip = await gzipSize(outfile)
         const maxsize = bytes(ctx.bundlesizeMax)
+
+        if (maxsize == null) {
+          throw new Error(`Could not parse bytes from "${ctx.bundlesizeMax}"`)
+        }
+
         const diff = gzip - maxsize
 
         task.output = 'Use https://esbuild.github.io/analyze/ to load "./dist/stats.json".'

--- a/src/document-check.js
+++ b/src/document-check.js
@@ -11,7 +11,15 @@ import { formatCode, formatError, fromRoot, hasTsconfig, readJson } from './util
  * @typedef {import("./types").GlobalOptions} GlobalOptions
  * @typedef {import("./types").DocsVerifierOptions} DocsVerifierOptions
  * @typedef {import("listr").ListrTaskWrapper} Task
+ * @typedef {import("ts-node").TSError} TSError
  */
+
+/**
+ * A list of tsc errors to ignore when compiling code snippets in documentation.
+ */
+const TS_ERRORS_TO_SUPRESS = [
+  2307 // Cannot find module '...' or its corresponding type declarations
+]
 
 const tasks = new Listr(
   [
@@ -54,7 +62,8 @@ const tasks = new Listr(
                     target: 'esnext',
                     module: 'esnext',
                     noImplicitAny: true,
-                    noEmit: true
+                    noEmit: true,
+                    skipLibCheck: true
                   }
                 }
               ])
@@ -64,6 +73,15 @@ const tasks = new Listr(
 
             results.forEach((result) => {
               if (result.error) {
+                // ignore some diagnostic codes
+                if (isTSError(result.error)) {
+                  const diagnosticCodes = result.error?.diagnosticCodes?.filter(code => !TS_ERRORS_TO_SUPRESS.includes(code))
+
+                  if (diagnosticCodes.length === 0) {
+                    return
+                  }
+                }
+
                 process.exitCode = 1
                 console.log(kleur.red().bold(`Error compiling example code block ${result.index} in file ${result.file}:`))
                 console.log(formatError(result.error))
@@ -89,3 +107,12 @@ const tasks = new Listr(
 )
 
 export default tasks
+
+/**
+ *
+ * @param {*} err
+ * @returns {err is TSError}
+ */
+function isTSError (err) {
+  return Array.isArray(err.diagnosticCodes)
+}

--- a/test/fixtures/document-check/pass/GOODREADME.md
+++ b/test/fixtures/document-check/pass/GOODREADME.md
@@ -1,3 +1,8 @@
 ```ts
-export const a = 1;
+import { foo } from 'dep-we-do-not-have'
+
+// should not cause an error because we ignore TS2307
+foo()
+
+export const a = 1
 ```


### PR DESCRIPTION
Sometimes we want to show examples that use modules that aren't a dependency of the module we are documenting.

In this case tsc throws `TS2307` when trying to compile the example code block.

Ignore this error so we can just treat these deps as `any` while still getting the benefit of compiling the rest of the code block.