### PR TITLE
chore: remove undici

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,8 +325,7 @@
     "@types/strong-log-transformer": "^1.0.2",
     "@types/yargs": "^17.0.0",
     "electron": "^33.2.1",
-    "uint8arrays": "^5.0.1",
-    "undici": "^6.2.1"
+    "uint8arrays": "^5.0.1"
   },
   "browser": {
     "fs": false,

--- a/test/utils/echo-server.js
+++ b/test/utils/echo-server.js
@@ -1,7 +1,6 @@
 /* eslint-env mocha */
 
 import { Buffer } from 'buffer'
-import { fetch } from 'undici'
 import { expect } from '../../utils/chai.js'
 import EchoServer from '../../utils/echo-server.js'
 


### PR DESCRIPTION
`fetch` is global in node so remove the undici dep.