### PR TITLE
fix: allow importing .ts files

### DIFF
--- a/src/config/tsconfig.aegir.json
+++ b/src/config/tsconfig.aegir.json
@@ -27,7 +27,8 @@
         "skipLibCheck": true,
         "stripInternal": true,
         "resolveJsonModule": true,
-        "rewriteRelativeImportExtensions": true
+        "rewriteRelativeImportExtensions": true,
+        "allowImportingTsExtensions": true
     },
     "include": [
         "src",


### PR DESCRIPTION
Turn on `allowImportingTsExtensions` to allow importing `.ts` files.

This is a prequisite of using Node.js type stripping in v24 (may be backported to v22).

Refs: https://github.com/libp2p/js-libp2p/issues/2812