### PR TITLE
fix: pin typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
     "typedoc-plugin-mdn-links": "^5.0.2",
     "typedoc-plugin-mermaid": "^1.12.0",
     "typedoc-plugin-missing-exports": "^4.0.0",
-    "typescript": "^5.1.6",
+    "typescript": "5.8.3",
     "typescript-docs-verifier": "^2.5.0",
     "wherearewe": "^2.0.1",
     "yargs": "^17.1.1",


### PR DESCRIPTION
Uint8Arrays are hopelessly broken in recent versions due to them being made generic so pin the version until this mess is sorted out.

Ref: https://github.com/microsoft/TypeScript/issues/61793