### PR TITLE
fix: print stack trace on error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ async function main () {
     if (res.parsed && (res.parsed.argv.debug || process.env.DEBUG != null)) {
       console.error('\n', err)
     } else {
-      console.error(err)
+      console.error(err.message)
     }
 
     process.exit(1)


### PR DESCRIPTION
When debugging issues with code imported from `.aegir.js` files, it's almost impossible to know where the error is coming from without seeing the whole stack trace so print the whole thing if a command fails.