### PR TITLE
fix: time out browser coverage collection

### DIFF
--- a/src/test/browser.js
+++ b/src/test/browser.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'url'
 import { execa } from 'execa'
 import merge from '../utils/merge-options.js'
 import { fromAegir, findBinary } from '../utils.js'
+import { killIfCoverageHangs } from './utils.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -41,7 +42,7 @@ export default async (argv, execaOptions) => {
   const beforeEnv = before && before.env ? before.env : {}
 
   // run pw-test
-  await execa(findBinary('pw-test'),
+  const proc = execa(findBinary('pw-test'),
     [
       ...files,
       '--mode', argv.runner === 'browser' ? 'main' : 'worker',
@@ -68,6 +69,8 @@ export default async (argv, execaOptions) => {
       execaOptions
     )
   )
+
+  await killIfCoverageHangs(proc, argv)
 
   // after hook
   await argv.fileConfig.test.after(argv, before)

--- a/src/test/node.js
+++ b/src/test/node.js
@@ -2,9 +2,9 @@ import os from 'os'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { execa } from 'execa'
-import kleur from 'kleur'
 import * as tempy from 'tempy'
 import merge from '../utils/merge-options.js'
+import { killIfCoverageHangs } from './utils.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -91,52 +91,7 @@ export default async function testNode (argv, execaOptions) {
     )
   )
 
-  let killedWhileCollectingCoverage = false
-
-  /** @type {ReturnType<setTimeout> | undefined} */
-  let timeout
-
-  if (argv.cov) {
-    proc.stderr?.addListener('data', (data) => {
-      process.stderr.write(data)
-    })
-
-    let lastLine = ''
-    proc.stdout?.addListener('data', (data) => {
-      process.stdout.write(data)
-
-      lastLine = data.toString()
-
-      if (lastLine.trim() !== '') {
-        // more output has been sent, reset timer
-        clearTimeout(timeout)
-      }
-
-      if (lastLine.match(/^ {2}\d+ (passing|pending)/m) != null) {
-        // if we see something that looks like the successful end of a mocha
-        // run, set a timer - if the process does not exit before the timer
-        // fires, kill it and log a warning, though don't cause the test run
-        // to fail
-        timeout = setTimeout(() => {
-          console.warn(kleur.red('!!! Collecting coverage has hung, killing process')) // eslint-disable-line no-console
-          console.warn(kleur.red('!!! See https://github.com/ipfs/aegir/issues/1206 for more information')) // eslint-disable-line no-console
-          killedWhileCollectingCoverage = true
-
-          proc.kill('SIGTERM')
-        }, argv.covTimeout).unref()
-      }
-    })
-  }
-
-  try {
-    await proc
-  } catch (err) {
-    if (!killedWhileCollectingCoverage) {
-      throw err
-    }
-  } finally {
-    clearTimeout(timeout)
-  }
+  await killIfCoverageHangs(proc, argv)
 
   // after hook
   await argv.fileConfig.test.after(argv, before)

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -1,0 +1,54 @@
+import kleur from 'kleur'
+
+/**
+ * @param {import('execa').ResultPromise<{}>} proc
+ * @param {{ cov: boolean, covTimeout: number }} argv
+ */
+export async function killIfCoverageHangs (proc, argv) {
+  let killedWhileCollectingCoverage = false
+
+  /** @type {ReturnType<setTimeout> | undefined} */
+  let timeout
+
+  if (argv.cov) {
+    proc.stderr?.addListener('data', (data) => {
+      process.stderr.write(data)
+    })
+
+    let lastLine = ''
+    proc.stdout?.addListener('data', (data) => {
+      process.stdout.write(data)
+
+      lastLine = data.toString()
+
+      if (lastLine.trim() !== '') {
+        // more output has been sent, reset timer
+        clearTimeout(timeout)
+      }
+
+      if (lastLine.match(/^ {2}\d+ (passing|pending)/m) != null) {
+        // if we see something that looks like the successful end of a mocha
+        // run, set a timer - if the process does not exit before the timer
+        // fires, kill it and log a warning, though don't cause the test run
+        // to fail
+        timeout = setTimeout(() => {
+          console.warn(kleur.red('!!! Collecting coverage has hung, killing process')) // eslint-disable-line no-console
+          console.warn(kleur.red('!!! See https://github.com/ipfs/aegir/issues/1206 for more information')) // eslint-disable-line no-console
+          killedWhileCollectingCoverage = true
+
+          proc.kill('SIGTERM')
+        }, argv.covTimeout).unref()
+      }
+    })
+  }
+
+  try {
+    await proc
+  } catch (err) {
+    if (!killedWhileCollectingCoverage) {
+      throw err
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/test/fixtures/dependency-check/jsx-fail/src/index.jsx
+++ b/test/fixtures/dependency-check/jsx-fail/src/index.jsx
@@ -1,9 +1,9 @@
 // @ts-expect-error - not installed
-// eslint-disable-next-line no-unused-vars
+
 import React from 'react'
 
 // @ts-expect-error - not installed
-// eslint-disable-next-line no-unused-vars
+
 const Component = () => (<div>Hello, world!</div>)
 const App = () => (<Component />)
 

--- a/test/fixtures/dependency-check/jsx-pass/src/index.jsx
+++ b/test/fixtures/dependency-check/jsx-pass/src/index.jsx
@@ -1,9 +1,9 @@
 // @ts-expect-error - not installed
-// eslint-disable-next-line no-unused-vars
+
 import React from 'react'
 
 // @ts-expect-error - not installed
-// eslint-disable-next-line no-unused-vars
+
 const Component = () => (<div>Hello, world!</div>)
 const App = () => (<Component />)
 


### PR DESCRIPTION
It seems browser coverage collection can hang in the same way node coverage does.