### PR TITLE
feat: add module-sync to default package config

### DIFF
--- a/src/check-project/manifests/typed-esm.js
+++ b/src/check-project/manifests/typed-esm.js
@@ -56,7 +56,8 @@ export async function typedESMManifest (context) {
       merge({
         '.': {
           types: './dist/src/index.d.ts',
-          import: './src/index.js'
+          import: './src/index.js',
+          'module-sync': './src/index.js'
         }
       }, manifest.exports)
     ),

--- a/src/check-project/manifests/typescript.js
+++ b/src/check-project/manifests/typescript.js
@@ -40,7 +40,8 @@ export async function typescriptManifest (context) {
       merge({
         '.': {
           types: './dist/src/index.d.ts',
-          import: './dist/src/index.js'
+          import: './dist/src/index.js',
+          'module-sync': './src/index.js'
         }
       }, manifest.exports)
     ),

--- a/src/check-project/manifests/untyped-esm.js
+++ b/src/check-project/manifests/untyped-esm.js
@@ -1,8 +1,12 @@
+import mergeOptions from '../../utils/merge-options.js'
 import { semanticReleaseConfig } from '../semantic-release-config.js'
 import {
   sortFields,
+  sortExportsMap,
   constructManifest
 } from '../utils.js'
+
+const merge = mergeOptions.bind({ ignoreUndefined: true })
 
 /**
  * @param {import('../index.js').ProcessManifestContext} context
@@ -31,12 +35,14 @@ export async function untypedESMManifest (context) {
       '!dist/test',
       '!**/*.tsbuildinfo'
     ],
-    exports: {
-      '.': {
-        types: './dist/src/index.d.ts',
-        import: './src/index.js'
-      }
-    },
+    exports: sortExportsMap(
+      merge({
+        '.': {
+          import: './dist/src/index.js',
+          'module-sync': './src/index.js'
+        }
+      }, manifest.exports)
+    ),
     release,
     scripts
   }, repoUrl, homePage)

--- a/src/check-project/utils.js
+++ b/src/check-project/utils.js
@@ -189,7 +189,7 @@ export function sortExportsMap (obj) {
 
     let types = entry.types
 
-    if (!types && entry.import != null) {
+    if (types == null && entry.import != null) {
       types = entry.import.replace('.js', '.d.ts')
     }
 
@@ -199,6 +199,15 @@ export function sortExportsMap (obj) {
       // types field must be first - https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing
       types,
       ...entry
+    }
+
+    // add `module-sync` field to allow `require`ing module - must be after
+    // import
+    if (output[key]['module-sync'] == null && output[key].import != null) {
+      output[key] = {
+        ...output[key],
+        'module-sync': output[key].import
+      }
     }
   }
 


### PR DESCRIPTION
Recent versions of Node.js support a `module-sync` option in the exports map.  This allows `require`ing ESM code that does not do any `await`ing at the top level.

None of our code should do this since it would add latency to module loading in an un-cancellable way.

Ref: https://nodejs.org/api/packages.html#conditional-exports