### PR TITLE
fix: update actions to node 24

### DIFF
--- a/actions/bundle-size/action.yml
+++ b/actions/bundle-size/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: A directory to run the bundle check in
     required: false
 runs:
-  using: 'node16'
+  using: 'node24'
   main: 'dist/index.js'

--- a/actions/cache-node-modules/action.yml
+++ b/actions/cache-node-modules/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     # Windows I/O is so slow it's faster to just install the deps every time
     - if: ${{ runner.os != 'Windows' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: cache
       with:
         path: |


### PR DESCRIPTION
Updates the bundle-size and cache-node-modules actions to use supported Node.js versions.