### PR TITLE
fix: revert "deps: bump @types/node from 22.19.7 to 25.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
     "@types/chai-string": "^1.4.2",
     "@types/chai-subset": "^1.3.3",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^25.6.0",
+    "@types/node": "^22.14.0",
     "@typescript-eslint/parser": "^8.32.1",
     "buffer": "^6.0.3",
     "bytes": "^3.1.0",


### PR DESCRIPTION
Reverts ipfs/aegir#1919

Changes to `Uint8Array` make this a breaking change.