### PR TITLE
fix: conditional build before test

### DIFF
--- a/src/config/user.js
+++ b/src/config/user.js
@@ -15,7 +15,7 @@ const defaults = {
   debug: false,
   // test cmd options
   test: {
-    build: false,
+    build: true,
     runner: 'node',
     target: ['node', 'browser', 'webworker'],
     watch: false,

--- a/src/test/deno.js
+++ b/src/test/deno.js
@@ -36,8 +36,8 @@ export default async function testNode (argv, execaOptions) {
     : [
         'test/deno.*js',
         'test/**/*.spec.*js',
-        'dist/test/deno.*js',
-        'dist/test/**/*.spec.*js'
+        'test/deno.*ts',
+        'test/**/*.spec.*ts'
       ]
 
   const args = [

--- a/src/test/electron.js
+++ b/src/test/electron.js
@@ -23,8 +23,10 @@ export default async (argv, execaOptions) => {
   const files = argv.files.length > 0
     ? [...argv.files]
     : [
+        `test/${argv.runner === 'electron-renderer' ? 'electron-renderer' : 'electron-main'}.*js`,
         'test/**/*.spec.*js',
-        'dist/test/**/*.spec.*js'
+        `test/${argv.runner === 'electron-renderer' ? 'electron-renderer' : 'electron-main'}.*ts`,
+        'test/**/*.spec.*ts'
       ]
   const grep = argv.grep ? ['--grep', argv.grep] : []
   const progress = argv.progress ? ['--reporter=progress'] : []

--- a/src/test/electron.js
+++ b/src/test/electron.js
@@ -61,6 +61,7 @@ export default async (argv, execaOptions) => {
       env: {
         AEGIR_RUNNER: argv.runner,
         NODE_ENV: process.env.NODE_ENV || 'test',
+        NODE_OPTIONS: '--experimental-strip-types --experimental-transform-types',
         ELECTRON_PATH: electronPath,
         ...beforeEnv
       }

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -7,6 +7,30 @@ import node from './node.js'
 import rn from './react-native.js'
 
 /**
+ * These environments can run `.ts` files natively so do not need a build step
+ */
+const NO_BUILD = [
+  'node',
+  'deno',
+  'electron-main'
+]
+
+/**
+ * @param {TestOptions & GlobalOptions} ctx
+ */
+function shouldBuild (ctx) {
+  if (ctx.build === false) {
+    return false
+  }
+
+  if (ctx.target.every(target => NO_BUILD.includes(target))) {
+    return false
+  }
+
+  return ctx.build
+}
+
+/**
  * @typedef {import("execa").Options} ExecaOptions
  * @typedef {import('../types.js').TestOptions} TestOptions
  * @typedef {import('../types.js').GlobalOptions} GlobalOptions
@@ -20,7 +44,7 @@ const TASKS = [
     /**
      * @param {TestOptions & GlobalOptions} ctx
      */
-    enabled: (ctx) => ctx.build === true,
+    enabled: (ctx) => shouldBuild(ctx),
 
     /**
      * @param {BuildOptions & GlobalOptions} ctx

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -12,7 +12,8 @@ import rn from './react-native.js'
 const NO_BUILD = [
   'node',
   'deno',
-  'electron-main'
+  'electron-main',
+  'electron-renderer'
 ]
 
 /**


### PR DESCRIPTION
Only build before tests if the target environment cannot run `.ts` files natively.