### PR TITLE
fix: default run concurrency to 1 in CI

### DIFF
--- a/src/config/user.js
+++ b/src/config/user.js
@@ -138,7 +138,8 @@ const defaults = {
   },
   run: {
     bail: true,
-    prefix: true
+    prefix: true,
+    concurrency: process.env.CI == null ? undefined : 1
   }
 }
 

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -157,6 +157,8 @@ export default {
         console.log(task.title) // eslint-disable-line no-console
       }
       return task.task(opts, execaOptions)
-    }, { concurrency: 1 })
+    }, {
+      concurrency: 1
+    })
   }
 }


### PR DESCRIPTION
When the CI environmental variable is set, make `aegir run ...` have a default concurrency of 1, otherwise use the max available parallelism.

Fixes race conditions with things like installing browsers and/or electron.