### PR TITLE
fix: override yazul version

### DIFF
--- a/package.json
+++ b/package.json
@@ -345,5 +345,8 @@
     "fs": false,
     "./utils/fixtures.js": "./utils/fixtures.browser.js",
     "./utils/resolve.js": "./utils/resolve.browser.js"
+  },
+  "overrides": {
+    "yazul": "^3.0.0"
   }
 }


### PR DESCRIPTION
Specify `yazul@3.x.x` because `yazul@2.x.x` has issues with modern node.js versions.

Can be reverted if https://github.com/max-mapper/extract-zip/issues/154 is ever resolved.