### PR TITLE
fix: vendor extract-zip

### DIFF
--- a/dictionaries/ipfs.txt
+++ b/dictionaries/ipfs.txt
@@ -285,3 +285,4 @@ dweb
 tlru
 hashlru
 peerid
+yazul

--- a/package.json
+++ b/package.json
@@ -266,7 +266,6 @@
     "eslint-plugin-jsdoc": "^62.3.1",
     "eslint-plugin-no-only-tests": "^3.3.0",
     "execa": "^9.5.3",
-    "extract-zip": "^2.0.1",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.1.0",
     "gh-pages": "^6.0.0",
@@ -320,7 +319,8 @@
     "typescript-docs-verifier": "^3.0.1",
     "wherearewe": "^2.0.1",
     "yargs": "^18.0.0",
-    "yargs-parser": "^22.0.0"
+    "yargs-parser": "^22.0.0",
+    "yauzl": "^3.3.1"
   },
   "devDependencies": {
     "@types/bytes": "^3.1.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,6 @@ import { constants, createBrotliCompress, createGzip } from 'node:zlib'
 import { download } from '@electron/get'
 import envPaths from 'env-paths'
 import { execa } from 'execa'
-import extract from 'extract-zip'
 import fg from 'fast-glob'
 import fs from 'fs-extra'
 import kleur from 'kleur'
@@ -24,6 +23,7 @@ import { readPackageUpSync } from 'read-pkg-up'
 import stripBom from 'strip-bom'
 import stripComments from 'strip-json-comments'
 import logTransformer from 'strong-log-transformer'
+import { unzip } from './utils/unzip.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const EnvPaths = envPaths('aegir', { suffix: '' })
@@ -174,7 +174,7 @@ export const getElectron = async () => {
     title: 'Extracting electron to system cache',
     enabled: () => !fs.existsSync(electronPath),
     task: async () => {
-      await extract(zipPath, { dir: path.dirname(zipPath) })
+      await unzip(zipPath, { dir: path.dirname(zipPath) })
     }
   }])
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,7 @@ import { readPackageUpSync } from 'read-pkg-up'
 import stripBom from 'strip-bom'
 import stripComments from 'strip-json-comments'
 import logTransformer from 'strong-log-transformer'
-import { unzip } from './utils/unzip.js'
+import { extract } from './utils/extract-zip.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const EnvPaths = envPaths('aegir', { suffix: '' })
@@ -174,7 +174,7 @@ export const getElectron = async () => {
     title: 'Extracting electron to system cache',
     enabled: () => !fs.existsSync(electronPath),
     task: async () => {
-      await unzip(zipPath, { dir: path.dirname(zipPath) })
+      await extract(zipPath, { dir: path.dirname(zipPath) })
     }
   }])
 

--- a/src/utils/extract-zip.js
+++ b/src/utils/extract-zip.js
@@ -193,7 +193,7 @@ class Extractor {
  * @param {UnzipOpts} opts
  * @returns
  */
-export async function unzip (zipPath, opts) {
+export async function extract (zipPath, opts) {
   if (!path.isAbsolute(opts.dir)) {
     throw new Error('Target directory is expected to be absolute')
   }

--- a/src/utils/unzip.js
+++ b/src/utils/unzip.js
@@ -1,0 +1,194 @@
+import path from 'node:path'
+import stream from 'node:stream'
+import { text } from 'node:stream/consumers'
+import { promisify } from 'node:util'
+import fs from 'fs-extra'
+import yauzl from 'yauzl'
+
+/** @type {(path: string, options: yauzl.Options) => Promise<yauzl.ZipFile>} */
+const openZip = promisify(yauzl.open)
+const pipeline = promisify(stream.pipeline)
+
+/**
+ * @typedef UnzipOpts
+ * @property {string} dir The directory to extract to
+ * @property {number | string} [defaultDirMode] Override the default dir mode
+ * @property {number | string} [defaultFileMode] Override the default file mode
+ * @property {(entry: yauzl.Entry, zip: yauzl.ZipFile) => void} [onEntry] Callback to handle directory entries
+ */
+
+class Extractor {
+  /**
+   * @param {string} zipPath
+   * @param {UnzipOpts} opts
+   */
+  constructor (zipPath, opts) {
+    this.zipPath = zipPath
+    this.opts = opts
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  async extract () {
+    const zipfile = await openZip(this.zipPath, {
+      lazyEntries: true
+    })
+    this.canceled = false
+
+    return new Promise((resolve, reject) => {
+      zipfile.on('error', err => {
+        this.canceled = true
+        reject(err)
+      })
+      zipfile.readEntry()
+
+      zipfile.on('close', () => {
+        if (!this.canceled) {
+          resolve()
+        }
+      })
+
+      zipfile.on('entry', async entry => {
+        /* istanbul ignore if */
+        if (this.canceled) {
+          return
+        }
+
+        if (entry.fileName.startsWith('__MACOSX/')) {
+          zipfile.readEntry()
+          return
+        }
+
+        const destDir = path.dirname(path.join(this.opts.dir, entry.fileName))
+
+        try {
+          await fs.mkdir(destDir, { recursive: true })
+
+          const canonicalDestDir = await fs.realpath(destDir)
+          const relativeDestDir = path.relative(this.opts.dir, canonicalDestDir)
+
+          if (relativeDestDir.split(path.sep).includes('..')) {
+            throw new Error(`Out of bound path "${canonicalDestDir}" found while processing file ${entry.fileName}`)
+          }
+
+          await this.extractEntry(entry, zipfile)
+          zipfile.readEntry()
+        } catch (err) {
+          this.canceled = true
+          zipfile.close()
+          reject(err)
+        }
+      })
+    })
+  }
+
+  /**
+   * @param {yauzl.Entry} entry
+   * @param {yauzl.ZipFile} zipfile
+   */
+  async extractEntry (entry, zipfile) {
+    /* istanbul ignore if */
+    if (this.canceled) {
+      return
+    }
+
+    if (this.opts.onEntry) {
+      this.opts.onEntry(entry, zipfile)
+    }
+
+    const dest = path.join(this.opts.dir, entry.fileName)
+
+    // convert external file attr int into a fs stat mode int
+    const mode = (entry.externalFileAttributes >> 16) & 0xFFFF
+    // check if it's a symlink or dir (using stat mode constants)
+    const IFMT = 61440
+    const IFDIR = 16384
+    const IFLNK = 40960
+    const symlink = (mode & IFMT) === IFLNK
+    let isDir = (mode & IFMT) === IFDIR
+
+    // Failsafe, borrowed from jsZip
+    if (!isDir && entry.fileName.endsWith('/')) {
+      isDir = true
+    }
+
+    // check for windows weird way of specifying a directory
+    // https://github.com/maxogden/extract-zip/issues/13#issuecomment-154494566
+    const madeBy = entry.versionMadeBy >> 8
+    if (!isDir) { isDir = (madeBy === 0 && entry.externalFileAttributes === 16) }
+
+    const procMode = this.getExtractedMode(mode, isDir) & 0o777
+
+    // always ensure folders are created
+    const destDir = isDir ? dest : path.dirname(dest)
+
+    /** @type {fs.MakeDirectoryOptions} */
+    const mkdirOptions = { recursive: true }
+    if (isDir) {
+      mkdirOptions.mode = procMode
+    }
+    await fs.mkdir(destDir, mkdirOptions)
+    if (isDir) { return }
+
+    const readStream = await promisify(zipfile.openReadStream.bind(zipfile))(entry)
+
+    if (symlink) {
+      const link = await text(readStream)
+      await fs.symlink(link, dest)
+    } else {
+      await pipeline(readStream, fs.createWriteStream(dest, { mode: procMode }))
+    }
+  }
+
+  /**
+   * @param {number} entryMode
+   * @param {boolean} isDir
+   * @returns {number}
+   */
+  getExtractedMode (entryMode, isDir) {
+    let mode = entryMode
+    // Set defaults, if necessary
+    if (mode === 0) {
+      if (isDir) {
+        if (this.opts.defaultDirMode != null) {
+          mode = parseInt(`${this.opts.defaultDirMode}`, 10)
+        }
+
+        if (!mode) {
+          mode = 0o755
+        }
+      } else {
+        if (this.opts.defaultFileMode != null) {
+          mode = parseInt(`${this.opts.defaultFileMode}`, 10)
+        }
+
+        if (!mode) {
+          mode = 0o644
+        }
+      }
+    }
+
+    return mode
+  }
+}
+
+/**
+ *
+ * @param {string} zipPath
+ * @param {UnzipOpts} opts
+ * @returns
+ */
+export async function unzip (zipPath, opts) {
+  if (!path.isAbsolute(opts.dir)) {
+    throw new Error('Target directory is expected to be absolute')
+  }
+
+  await fs.mkdir(opts.dir, {
+    recursive: true
+  })
+
+  opts.dir = await fs.realpath(opts.dir)
+
+  return new Extractor(zipPath, opts).extract()
+}

--- a/src/utils/unzip.js
+++ b/src/utils/unzip.js
@@ -1,3 +1,12 @@
+/**
+ * Source code of `extract-zip` which was used previously however is broken on
+ * Node 26 due to a dependency on an older version of yazul.
+ *
+ * This file can be removed if/when the issues are resolved upstream.
+ *
+ * https://github.com/ipfs/aegir/pull/1965
+ * https://github.com/max-mapper/extract-zip/issues/154
+ */
 import path from 'node:path'
 import stream from 'node:stream'
 import { text } from 'node:stream/consumers'

--- a/src/utils/unzip.js
+++ b/src/utils/unzip.js
@@ -102,10 +102,15 @@ class Extractor {
     // convert external file attr int into a fs stat mode int
     const mode = (entry.externalFileAttributes >> 16) & 0xFFFF
     // check if it's a symlink or dir (using stat mode constants)
+    // spell-checker: disable-next-line
     const IFMT = 61440
+    // spell-checker: disable-next-line
     const IFDIR = 16384
+    // spell-checker: disable-next-line
     const IFLNK = 40960
+    // spell-checker: disable-next-line
     const symlink = (mode & IFMT) === IFLNK
+    // spell-checker: disable-next-line
     let isDir = (mode & IFMT) === IFDIR
 
     // Failsafe, borrowed from jsZip


### PR DESCRIPTION
The `extract-zip` dep is unmaintained and is [currently broken](https://github.com/max-mapper/extract-zip/issues/154) on Node 26, although the problem has been fixed in more recent versions of `yazul`.

Every other popular unzipping library seems to have a different problem so vendor in `extract-zip` until/if the issues are resolved upstream.