### PR TITLE
fix: allow zeros in peer ids

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -37,23 +37,23 @@
     "/CID(.*)/",
 
     // string CIDs are not spell checked
-    "baf[a-zA-Z1-9\/]+", // base32 encoded libp2p-key
-    "bae[a-zA-Z1-9\/]+", // base32 encoded identity
-    "Qm[a-zA-Z1-9\/]+", // base58btc encoded (no multibase)
+    "baf[a-zA-Z0-9\/]+", // base32 encoded libp2p-key
+    "bae[a-zA-Z0-9\/]+", // base32 encoded identity
+    "Qm[a-zA-Z0-9\/]+", // base58btc encoded (no multibase)
 
     // string PeerIds are not spell checked
-    "12D3Koo[a-zA-Z1-9\/]+", // Ed25519
-    "16Uiu[a-zA-Z1-9\/]+", // secp256k1
-    "k51[a-zA-Z1-9\/]+", // base36 ed PeerId as CID
-    "kzw[a-zA-Z1-9\/]+", // base36 secp PeerId as CID
-    "k2k[a-zA-Z1-9\/]+", // base36 rsa PeerId as CID
+    "12D3Koo[a-zA-Z0-9\/]+", // Ed25519
+    "16Uiu[a-zA-Z0-9\/]+", // secp256k1
+    "k51[a-zA-Z0-9\/]+", // base36 ed PeerId as CID
+    "kzw[a-zA-Z0-9\/]+", // base36 secp PeerId as CID
+    "k2k[a-zA-Z0-9\/]+", // base36 rsa PeerId as CID
 
-    "/ipfs/[a-zA-Z1-9\/]+", // IPFS paths
-    "ipfs://[a-zA-Z1-9\/]+", // IPFS URLs
-    "/ipns/[a-zA-Z1-9\/\\.]+", // IPNS names
-    "ipns://[a-zA-Z1-9\/\\.]+", // IPNS URLs
+    "/ipfs/[a-zA-Z0-9\/]+", // IPFS paths
+    "ipfs://[a-zA-Z0-9\/]+", // IPFS URLs
+    "/ipns/[a-zA-Z0-9\/\\.]+", // IPNS names
+    "ipns://[a-zA-Z0-9\/\\.]+", // IPNS URLs
 
-    "AAE[a-zA-Z1-9\/]+", // base64 data
+    "AAE[a-zA-Z0-9\/]+", // base64 data
     "%[a-fA-F0-9]{2}" // URL encoded characters
   ]
 }


### PR DESCRIPTION
Fix spell check ignores to allow 0-9 instead of just 1-9 in peerids/cids/etc